### PR TITLE
Fixed bug in background_waves class

### DIFF
--- a/src/background_waves.cc
+++ b/src/background_waves.cc
@@ -262,7 +262,4 @@ void BackgroundWaves::EvaluateDmax(void)
    LOWER_BITS(_status, STATE_INVALID);
 };
 
-template void DataContainer::Insert <TurbProp>(TurbProp data);
-template void DataContainer::Read <TurbProp>(TurbProp* data_ptr);
-
 };

--- a/src/background_waves.hh
+++ b/src/background_waves.hh
@@ -11,36 +11,9 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 
 #include "background_base.hh"
 #include "common/matrix.hh"
+#include "common/turb_prop.hh"
 
 namespace Spectrum {
-
-//! Number of turbulence types
-const int n_turb_types = 4;
-
-//! Turbulence types that can be generated
-enum turb_type {turb_alfven, turb_transverse, turb_longitudinal, turb_isotropic};
-
-//! Packaged input parameter structure per wave type
-struct TurbProp {
-
-//! Smallest wavenumber
-   double kmin;
-
-//! Largest wavenumber
-   double kmax;
-
-//! Characteristic length
-   double l0;
-
-//! Number of modes
-   double n_waves;
-
-//! Variance
-   double variance;
-
-//! Power law slope
-   double slope;
-};
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 // BackgroundWaves class declaration


### PR DESCRIPTION
Removed duplicate declaration of TurbProp type for Read and Insert functions in DataContainer class. These declarations are already in common/data_container.cc.