### PR TITLE
Numerical Derivatives and Other Updates

### DIFF
--- a/benchmarks/benchmark_explained.txt
+++ b/benchmarks/benchmark_explained.txt
@@ -53,6 +53,7 @@ This file contains benchmark tests for SPECTRUM.
    - Trajectory type: fieldline
    - Field type: solarwind
    - Expected result: The trajectory should trace the Parker spiral magnetic field.
+   - Notes: Make sure that "SOLARWIND_CURRENT_SHEET" is  (#)defined as 0 in src/background_solarwind.hh.
 
 - INITIAL CONDITION RECORDS TEST
    - File: main_test_init_cond_records.cc
@@ -65,4 +66,4 @@ This file contains benchmark tests for SPECTRUM.
    - Trajectory type: parker
    - Field type: cartesian
    - Expected result: An initial spectrum given by a power law in differential density should be modulated through a uniformly discretized parker spiral (via a cartesian background). The auxiliary file 'main_postprocess_modulation_cartesian_parker.cc' post-processed the data to differential intensity and outputs it to 'test_modulation_cartesian_TrajectoryParker_spectrum_pp.dat' along with an approximate theoretical solution given by Fisk & Axford (1969). The solutions should match well with perhaps a small discrepancy at low energies but very good agreement at high energies.
-   - Notes: Make sure that "DISTRO_KINETIC_ENERGY_POWER_LAW_TYPE" is (#)defined as 0 in src/distribution_other.hh. In addition, all server units must match spectrum fluid units, and the "SERVER_VAR_INDEX_" for "FLO", "MAG", and "ELE" must be set to 0, 3, and 6, respectively, in src/server_base.hh. Finally, "block_size_cartesian" should be set to (4,4,4) in src/reader_cartesian.hh, and "n_variables_cartesian" must be set to 9 in src/block_cartesian.hh.
+   - Notes: Make sure that "DISTRO_KINETIC_ENERGY_POWER_LAW_TYPE" is (#)defined as 0 in src/distribution_other.hh. In addition, all server units must match spectrum fluid units, and the "SERVER_VAR_INDEX_" for "FLO", "MAG", and "ELE" must be set to 0, 3, and 6, respectively, in src/server_base.hh. Also, "block_size_cartesian" should be set to (4,4,4) in src/reader_cartesian.hh, and "n_variables_cartesian" must be set to 9 in src/block_cartesian.hh. Finally, the line (#)defining "TRAJ_PARKER_USE_B_DRIFTS" must be commented out in src/trajectory_parker.hh.

--- a/benchmarks/main_generate_cartesian_solarwind_background.cc
+++ b/benchmarks/main_generate_cartesian_solarwind_background.cc
@@ -35,7 +35,8 @@ int main(void)
 // ========== PARKER SPIRAL ==========
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);
@@ -106,7 +107,7 @@ int main(void)
    GeoVector zone_length = (block_length) / block_size; // length of each zone
    GeoVector delta = 0.5 * zone_length; // half-length of each zone
    double t = 0.0; // time at which to output data
-   GeoVector center_min, pos; // position vectors
+   GeoVector center_min, pos, mom; // position vectors
    MultiIndex block_idx, zone_idx; // block and zone indices
 
    std::cerr << "Outputting data file. Progress:     ";
@@ -130,7 +131,7 @@ int main(void)
                   for(iz = 0; iz < block_size[0]; iz++) {
                      zone_idx.i = iz;
                      pos = center_min + zone_idx * zone_length;
-                     background.GetFields(t, pos, spdata);
+                     background.GetFields(t, pos, mom, spdata);
                      for(var = 0; var < 3; var++) data_file.write((char*)(&spdata.Uvec[var]), sizeof(double));
                      for(var = 0; var < 3; var++) data_file.write((char*)(&spdata.Bvec[var]), sizeof(double));
                      for(var = 0; var < 3; var++) data_file.write((char*)(&spdata.Evec[var]), sizeof(double));

--- a/benchmarks/main_test_dipole_periods.cc
+++ b/benchmarks/main_test_dipole_periods.cc
@@ -42,7 +42,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);
@@ -116,7 +117,7 @@ int main(int argc, char** argv)
 // Duration of the trajectory
    double drift_period = 3600.0 * 1.05 / MeV_kinetic_energy / L / (1.0 + 0.43 * sin(theta_eq)) / unit_time_fluid;
    double bounce_period = 2.41 * L * (1.0 - 0.43 * sin(theta_eq)) / sqrt(MeV_kinetic_energy) / unit_time_fluid;
-   double maxtime = 10.0 * drift_period;
+   double maxtime = 1.0 * drift_period;
    container.Insert(maxtime);
 
    trajectory->AddBoundary(BoundaryTimeExpire(), container);

--- a/benchmarks/main_test_dipole_visualization.cc
+++ b/benchmarks/main_test_dipole_visualization.cc
@@ -23,7 +23,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/benchmarks/main_test_full_diff.cc
+++ b/benchmarks/main_test_full_diff.cc
@@ -37,7 +37,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/benchmarks/main_test_init_cond_records.cc
+++ b/benchmarks/main_test_init_cond_records.cc
@@ -35,7 +35,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/benchmarks/main_test_modulation_cartesian_parker.cc
+++ b/benchmarks/main_test_modulation_cartesian_parker.cc
@@ -37,7 +37,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/benchmarks/main_test_pa_distro_isotrop.cc
+++ b/benchmarks/main_test_pa_distro_isotrop.cc
@@ -37,7 +37,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/benchmarks/main_test_pa_scatt.cc
+++ b/benchmarks/main_test_pa_scatt.cc
@@ -37,7 +37,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/benchmarks/main_test_parker_spiral.cc
+++ b/benchmarks/main_test_parker_spiral.cc
@@ -42,7 +42,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/benchmarks/main_test_perp_diff.cc
+++ b/benchmarks/main_test_perp_diff.cc
@@ -37,7 +37,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/benchmarks/main_test_turb_waves.cc
+++ b/benchmarks/main_test_turb_waves.cc
@@ -40,7 +40,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/common/data_container.cc
+++ b/common/data_container.cc
@@ -241,8 +241,10 @@ void DataContainer::Print(void)
    _param = storage;
 
 // Print the byte decimal representation of the parameters
+   std::cout << std::hex;
+   std::cout << std::setfill('0');
    for(size_t i = 0; i < n_records; i++) {
-      for(uint8_t j = 1; j <= *_param; j++) std::cout << std::setw(4) << _param[j];
+      for(uint8_t j = 1; j <= *_param; j++) std::cout << " " << std::setw(2) << (int)_param[j];
       std::cout << std::endl;
       _param += *_param + 1;
    };

--- a/common/spatial_data.hh
+++ b/common/spatial_data.hh
@@ -166,12 +166,15 @@ struct SpatialData {
 
 //! Gradient of bhat
    GeoMatrix gradbhat(void);
+
+//! Time derivative of bhat
+   GeoVector dbhatdt(void);
 };
 
 /*!
 \author Juan G Alonso Guzman
 \author Vladimir Florinski
-\date 07/11/2024
+\date 07/02/2024
 \param[in] other Structure to copy from
 \return Reference to the object
 */
@@ -295,7 +298,7 @@ inline GeoVector SpatialData::curlE(void)
 
 /*!
 \author Juan G Alonso Guzman
-\date 07/11/2024
+\date 07/02/2024
 \return Divergence of bhat
 \note The formula comes from applying vector identity (7) in the NRL Plasma formulary
 */
@@ -306,7 +309,7 @@ inline double SpatialData::divbhat(void)
 
 /*!
 \author Juan G Alonso Guzman
-\date 07/11/2024
+\date 07/02/2024
 \return Curl of bhat
 \note The formula comes from applying vector identity (8) in the NRL Plasma formulary
 */
@@ -317,7 +320,7 @@ inline GeoVector SpatialData::curlbhat(void)
 
 /*!
 \author Juan G Alonso Guzman
-\date 07/11/2024
+\date 07/02/2024
 \return Gradient of bhat
 \note The formula comes from expanding \partial_i bhat_j = d/dx^i (B_j / B)
 */
@@ -326,6 +329,16 @@ inline GeoMatrix SpatialData::gradbhat(void)
    GeoMatrix mat_tmp;
    mat_tmp.Dyadic(gradBmag, bhat);
    return (gradBvec - mat_tmp) / Bmag;
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 07/02/2024
+\return Time derivative of bhat
+*/
+inline GeoVector SpatialData::dbhatdt(void)
+{
+   return (dBvecdt - (dBmagdt * bhat)) / Bmag;
 };
 
 };

--- a/runs/gcr_modulation_example.cc
+++ b/runs/gcr_modulation_example.cc
@@ -37,7 +37,8 @@ int main(int argc, char** argv)
    container.Clear();
 
 // Initial time
-   container.Insert(0.0);
+   double t0 = 0.0;
+   container.Insert(t0);
 
 // Origin
    container.Insert(gv_zeros);

--- a/src/background_base.cc
+++ b/src/background_base.cc
@@ -298,7 +298,7 @@ void BackgroundBase::NumericalDerivatives(void)
    _spdata._mask >>= mask_offset;
    if(BITS_RAISED(_spdata._mask, BACKGROUND_ALL)) {
 // Derivatives are only needed for trajectory types whose transport assumes the background changes on scales longer than the gyro-frequency.
-      w_g = fmin(CyclotronFrequency(Vel(_mom[0]), _spdata.Bmag, specie), _spdata.dmax / Vel(_mom[0]));
+      w_g = fmin(CyclotronFrequency(Vel(_mom[0]), _spdata.Bmag, specie), Vel(_mom[0]) / _spdata.dmax);
       DirectionalDerivative(3);
    };
 

--- a/src/background_base.cc
+++ b/src/background_base.cc
@@ -248,7 +248,7 @@ void BackgroundBase::NumericalDerivatives(void)
    _spdata._mask >>= mask_offset;
    if(BITS_RAISED(_spdata._mask, BACKGROUND_ALL)) {
 // Derivatives are only needed for trajectory types whose transport assumes the background changes on scales larger than the gyro-radius.
-      r_g = LarmorRadius(_mom[0], _spdata.Bmag, specie);
+      r_g = fmin(LarmorRadius(_mom[0], _spdata.Bmag, specie), _spdata.dmax);
 
 // Get field aligned basis in (transpose) of rotation matrix
       fa_basis.row[2] = _spdata.bhat;
@@ -298,7 +298,7 @@ void BackgroundBase::NumericalDerivatives(void)
    _spdata._mask >>= mask_offset;
    if(BITS_RAISED(_spdata._mask, BACKGROUND_ALL)) {
 // Derivatives are only needed for trajectory types whose transport assumes the background changes on scales longer than the gyro-frequency.
-      w_g = CyclotronFrequency(Vel(_mom[0]), _spdata.Bmag, specie);
+      w_g = fmin(CyclotronFrequency(Vel(_mom[0]), _spdata.Bmag, specie), _spdata.dmax / Vel(_mom[0]));
       DirectionalDerivative(3);
    };
 
@@ -404,6 +404,7 @@ void BackgroundBase::StopServerFront(void)
 */
 double BackgroundBase::GetSafeIncr(const GeoVector& dir)
 {
+//FIXME: This is incomplete.
    return incr_dmax_ratio * _spdata.dmax;
 };
 
@@ -426,7 +427,7 @@ void BackgroundBase::GetFields(double t_in, const GeoVector& pos_in, const GeoVe
    };
 
 // If "EvaluateDmax()" fails, the state will be set to "STATE_INVALID" and background will not be evaluated
-   SetState(t_in + t0, pos_in, mom_in);
+   SetState(t_in, pos_in, mom_in);
    EvaluateDmax();
    if(BITS_RAISED(_status, STATE_INVALID)) throw ExCoordinates();
 

--- a/src/background_base.hh
+++ b/src/background_base.hh
@@ -19,7 +19,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 #include "src/server_config.hh"
 
 #include <memory>
-//#include <iostream>
 #ifdef USE_SILO
 #include <silo.h>
 #endif
@@ -27,7 +26,7 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 namespace Spectrum {
 
 //! Number of local coordinate systems in which to evaluate and average numerical derivatives
-#define BACKGROUND_NUM_GRAD_EVALS 8
+#define BACKGROUND_NUM_GRAD_EVALS 1
 
 #ifdef USE_SILO
 
@@ -88,11 +87,14 @@ inline const char* ExFieldError::what(void) const noexcept
 
 The BackgroundXXXXX" classes describe plasma condition (u, E, B, dB/dt, gradB) at an arbitrary location. In the simplest scenario these are computed analytically from a known formula. A more complex situation is when the background is provided externally, typically from a file produced from a numerical simulation. Derived classes may contain an interface to read mesh based output files and calculate field values using interpolation.
 
-Parameters: GeoVector r0, GeoVector u0, GeoVector B0, double dmax0
+Parameters: double t0, GeoVector r0, GeoVector u0, GeoVector B0, double dmax0
 */
 class BackgroundBase : public Params {
 
 protected:
+
+//! Initial time (persistent)
+   double t0;
 
 //! Coordinate system origin (persistent)
    GeoVector r0;

--- a/src/background_dipole.cc
+++ b/src/background_dipole.cc
@@ -100,10 +100,14 @@ void BackgroundDipole::EvaluateBackgroundDerivatives(void)
       rr.Dyadic(posprime);
 
       _spdata.gradBvec = 3.0 * (mr + rm + mdotr * (gm_unit - 5.0 * rr / r2)) / r5;
+      _spdata.gradBmag = _spdata.gradBvec * _spdata.bhat;
    };
    if(BITS_RAISED(_spdata._mask, BACKGROUND_gradE)) _spdata.gradEvec = gm_zeros;
    if(BITS_RAISED(_spdata._mask, BACKGROUND_dUdt)) _spdata.dUvecdt = gv_zeros;
-   if(BITS_RAISED(_spdata._mask, BACKGROUND_dBdt)) _spdata.dBvecdt = gv_zeros;
+   if(BITS_RAISED(_spdata._mask, BACKGROUND_dBdt)) {
+      _spdata.dBvecdt = gv_zeros;
+      _spdata.dBmagdt = 0.0;
+   };
    if(BITS_RAISED(_spdata._mask, BACKGROUND_dEdt)) _spdata.dEvecdt = gv_zeros;
 
 #else

--- a/src/background_smooth_shock.cc
+++ b/src/background_smooth_shock.cc
@@ -7,7 +7,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 */
 
 #include "background_smooth_shock.hh"
-#include <iostream>
 
 namespace Spectrum {
 

--- a/src/background_smooth_shock.hh
+++ b/src/background_smooth_shock.hh
@@ -13,7 +13,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 
 namespace Spectrum {
 
-
 //! Flag to control smoothness of shock
 #define SMOOTH_SHOCK_ORDER 1
 

--- a/src/background_solarwind.cc
+++ b/src/background_solarwind.cc
@@ -131,12 +131,13 @@ void BackgroundSolarWind::EvaluateBackground(void)
    _spdata.region[1] = -1.0;
 // Assign magnetic mixing region
 #if SOLARWIND_CURRENT_SHEET >= 2
-   t_lag = TimeLag(r) - _t;
+   t_lag = TimeLag(r) - (_t - t0);
 // Constant tilt
    tilt_amp = tilt_ang_sw;
 #if SOLARWIND_CURRENT_SHEET == 3
 // Variable tilt
-   tilt_amp += dtilt_ang_sw * cos(2.0 * W0_sw * t_lag);
+   double arg = 2.0 * W0_sw * t_lag;
+   tilt_amp += dtilt_ang_sw * cos(CubicStretch(arg - M_2PI * floor(arg / M_2PI)));
 #endif
 #endif
 #if SOLARWIND_SECTORED_REGION >= 1
@@ -214,7 +215,7 @@ void BackgroundSolarWind::EvaluateBackground(void)
       if(acos(costheta) > M_PI_2 + tilt_amp * (sinphi * cosphase + cosphi * sinphase)) _spdata.Bvec *= -1.0;
 #if SOLARWIND_CURRENT_SHEET == 3
 // Solar cycle polarity changes
-      if(sin(W0_sw * t_lag) < 0.0) _spdata.Bvec *= -1.0;
+      if(sin(W0_sw * t_lag) > 0.0) _spdata.Bvec *= -1.0;
 #endif
 #endif
       _spdata.Bvec.ChangeFromBasis(eprime);

--- a/src/background_solarwind.hh
+++ b/src/background_solarwind.hh
@@ -18,10 +18,10 @@ namespace Spectrum {
 #define SOLARWIND_DERIVATIVE_METHOD 1
 
 //! Heliospheric current sheet (0: disabled, 1: flat, 2: wavy (Jokipii-Thomas 1981) and static, 3: wavy and time-dependent).
-#define SOLARWIND_CURRENT_SHEET 3
+#define SOLARWIND_CURRENT_SHEET 0
 
 //! Magnetic topology region (0: nowhere, 1: same as HCS, 2: HCS + hollow sphere)
-#define SOLARWIND_SECTORED_REGION 1
+#define SOLARWIND_SECTORED_REGION 0
 
 //! Correction to Parker Spiral, mainly for polar regions (0: none, 1: Smith-Bieber 1991, 2: Zurbuchen et al. 1997, 3: Schwadron-McComas 2003)
 #define SOLARWIND_POLAR_CORRECTION 0
@@ -30,24 +30,27 @@ namespace Spectrum {
 #define SOLARWIND_SPEED_LATITUDE_PROFILE 0
 
 //! Magnetic axis tilt angle relative to the solar rotation axis
-const double tilt_ang_sw = 45.0 * M_PI / 180.0;
+const double tilt_ang_sw = 40.0 * M_PI / 180.0;
 
 #if SOLARWIND_CURRENT_SHEET == 3
 //! Magnetic axis tilt angle relative to the solar rotation axis
-const double dtilt_ang_sw = 30.0 * M_PI / 180.0;
+const double dtilt_ang_sw = 35.0 * M_PI / 180.0;
 
 //! Solar cycle frequency
 const double W0_sw = M_2PI / (60.0 * 60.0 * 24.0 * 365.0 * 22.0) / unit_frequency_fluid;
+
+//! Factor to thin peaks and widen troughs (0.0: largest modification, 1.0: no modification)
+const double stilt_ang_sw = 1.0;
 #endif
 
 #if SOLARWIND_SECTORED_REGION == 2
 //! Radial distance to start sectored region
-const double sectored_radius_sw = 100.0 * GSL_CONST_CGSM_ASTRONOMICAL_UNIT / unit_length_fluid;
+const double sectored_radius_sw = 114.0 * GSL_CONST_CGSM_ASTRONOMICAL_UNIT / unit_length_fluid;
 #endif
 
 #if SOLARWIND_POLAR_CORRECTION > 0
 //! Differential rotation factor
-const double delta_omega_sw = 0.15;
+const double delta_omega_sw = 0.1;
 #endif
 
 #if SOLARWIND_POLAR_CORRECTION == 2
@@ -145,6 +148,11 @@ protected:
 //! Compute the maximum distance per time step
    void EvaluateDmax(void) override;
 
+#if SOLARWIND_CURRENT_SHEET == 3
+//! Function to compress peaks and stretch troughs
+   double CubicStretch(double t) const;
+#endif
+
 public:
 
 //! Default constructor
@@ -162,6 +170,20 @@ public:
 //! Clone function
    CloneFunctionBackground(BackgroundSolarWind);
 };
+
+#if SOLARWIND_CURRENT_SHEET == 3
+/*!
+\author Juan G Alonso Guzman
+\date 07/16/2024
+\param[in] t periodic time to stretch between 0 and M_2PI
+\return stretched time
+*/
+inline double BackgroundSolarWind::CubicStretch(double t) const
+{
+   double t_pi = t / M_PI;
+   return t * ((1.0 - stilt_ang_sw) * t_pi * (t_pi - 3.0) + 3.0 - 2.0 * stilt_ang_sw);
+};
+#endif
 
 };
 

--- a/src/background_vlism_bochum.cc
+++ b/src/background_vlism_bochum.cc
@@ -9,8 +9,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 
 #include "background_vlism_bochum.hh"
 #include <gsl/gsl_sf_ellint.h>
-#include <iostream>
-#include <iomanip>
 
 namespace Spectrum {
 

--- a/src/background_waves.cc
+++ b/src/background_waves.cc
@@ -7,7 +7,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 */
 
 #include "background_waves.hh"
-#include <iostream>
 
 namespace Spectrum {
 

--- a/src/block_batl.cc
+++ b/src/block_batl.cc
@@ -8,8 +8,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 */
 
 #include "block_batl.hh"
-#include <iostream>
-#include <iomanip>
 
 namespace Spectrum {
 

--- a/src/diffusion_base.cc
+++ b/src/diffusion_base.cc
@@ -143,25 +143,25 @@ double DiffusionBase::GetDirectionalDerivative(int xyz)
 // Save position, compute increment
       _pos_saved = _pos;
 
-//FIXME: This computation of "Bvec" at a displaced position is exact if numerical derivatives are used, and a good estimate if "_dr" is small enough. However, when analytic derivatives are used, "_dr" is not modified after the initial setup, which could result in a bad approximation when "dmax" < "dmax0".
+//This computation of "Bvec" at a displaced position is exact if numerical derivatives are used, and a good estimate if "_dr" is small enough.
       _dr = 0.5 * _spdata._dr[xyz];
-      if(_spdata._dr_forw_fail[xyz]) {
+      if(_spdata._dr_forw_fail[xyz]) Kappa_forw[comp_eval] = Kappa_saved[comp_eval];
+      else {
          _pos[xyz] += _dr;
          _spdata.Bvec += _spdata.gradBvec.row[xyz] * _dr;
          _spdata.Bmag += _spdata.gradBmag[xyz] * _dr;
          EvaluateDiffusion();
          Kappa_forw[comp_eval] = Kappa[comp_eval];
-      }
-      else Kappa_forw[comp_eval] = Kappa_saved[comp_eval];
+      };
       _dr *= 2.0;
-      if(_spdata._dr_back_fail[xyz]) {
+      if(_spdata._dr_back_fail[xyz]) Kappa_back[comp_eval] = Kappa_saved[comp_eval];
+      else {
          _pos[xyz] -= _dr;
          _spdata.Bvec -= _spdata.gradBvec.row[xyz] * _dr;
          _spdata.Bmag -= _spdata.gradBmag[xyz] * _dr;
          EvaluateDiffusion();
          Kappa_back[comp_eval] = Kappa[comp_eval];
-      }
-      else Kappa_back[comp_eval] = Kappa_saved[comp_eval];
+      };
       if(_spdata._dr_forw_fail[xyz] || _spdata._dr_back_fail[xyz]) _dr *= 0.5;
 
       derivative = (Kappa_forw[comp_eval] - Kappa_back[comp_eval]) / _dr;

--- a/src/initial_base.cc
+++ b/src/initial_base.cc
@@ -8,8 +8,8 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 */
 
 #include "initial_base.hh"
-#include <iostream> // std::cout
-#include <fstream> // std::ifsteam
+#include <iostream>
+#include <fstream>
 
 namespace Spectrum {
 
@@ -103,9 +103,36 @@ GeoVector InitialBase::GetSample(const GeoVector& axis_in)
    axis = UnitVec(axis_in);
    EvaluateInitial();
 
-// Return the internal position or momentum
+// Return the internal position or momentum. Initial time will never be assigned this way.
    if(BITS_RAISED(_status, INITIAL_SPACE)) return _pos;
    else return _mom;
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// InitialTime methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Juan G Alonso Guzman
+\date 07/01/2024
+*/
+InitialTime::InitialTime(void)
+           : InitialBase(init_name_time, 0, INITIAL_TIME)
+{
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 07/01/2024
+\param[in] other Object to initialize from
+
+A copy constructor should first first call the Params' version to copy the data container and then check whether the other object has been set up. If yes, it should simply call the virtual method "SetupInitial()" with the argument of "true".
+*/
+InitialTime::InitialTime(const InitialTime& other)
+           : InitialBase(other)
+{
+   RAISE_BITS(_status, INITIAL_TIME);
+   if(BITS_RAISED(other._status, STATE_SETUP_COMPLETE)) SetupInitial(true);
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/initial_base.hh
+++ b/src/initial_base.hh
@@ -19,23 +19,26 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 
 namespace Spectrum {
 
+//! Condition is in time
+const uint16_t INITIAL_TIME = 0x0010;
+
 //! Condition is in space
-const uint16_t INITIAL_SPACE = 0x0010;
+const uint16_t INITIAL_SPACE = 0x0020;
 
 //! Condition is in momentum
-const uint16_t INITIAL_MOMENTUM = 0x0020;
+const uint16_t INITIAL_MOMENTUM = 0x0040;
 
 //! Condition is a single point
-const uint16_t INITIAL_POINT = 0x0040;
+const uint16_t INITIAL_POINT = 0x0080;
 
 //! Condition is a curve
-const uint16_t INITIAL_CURVE = 0x0080;
+const uint16_t INITIAL_CURVE = 0x0100;
 
 //! Condition is a surface
-const uint16_t INITIAL_SURFACE = 0x0100;
+const uint16_t INITIAL_SURFACE = 0x0200;
 
 //! Condition is a volume
-const uint16_t INITIAL_VOLUME = 0x0200;
+const uint16_t INITIAL_VOLUME = 0x0400;
 
 //! Clone function pattern
 #define CloneFunctionInitial(T) std::unique_ptr<InitialBase> Clone(void) const override {return std::make_unique<T>();};
@@ -88,11 +91,41 @@ public:
 //! Produce a realization of initial conditions based on an internal distribution function
    GeoVector GetSample(const GeoVector& axis_in);
 
+//! Tell if the class is for time
+   bool IsInitialTime(void) const;
+
 //! Tell if the class is for space coordinate
    bool IsInitialSpace(void) const;
 
 //! Tell if the class is for momentum coordinate
    bool IsInitialMomentum(void) const;
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// InitialTime class declaration
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+//! Readable name of the InitialTime class
+const std::string init_name_time = "InitialTime";
+
+/*!
+\brief Initial time condition. This class doubles as the "final" time for backward simulations. This class will not be used in the same way as position or momentum initial conditions, but is included here for completion.
+\author Juan G Alonso Guzman
+
+Parameters: (InitialBase)
+*/
+class InitialTime : public InitialBase {
+
+public:
+
+//! Default constructor
+   InitialTime(void);
+
+//! Copy constructor
+   InitialTime(const InitialTime& other);
+
+//! Clone function
+   CloneFunctionInitial(InitialTime);
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -139,6 +172,16 @@ public:
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 // InitialBase inline methods
 //----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Juan G Alonso Guzman
+\date 07/01/2024
+\return True if the class describes initial condition in time
+*/
+inline bool InitialBase::IsInitialTime(void) const
+{
+   return BITS_RAISED(_status, INITIAL_TIME);
+};
 
 /*!
 \author Vladimir Florinski

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -10,6 +10,7 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 #include "simulation.hh"
 #include "common/print_warn.hh"
 #include <numeric>
+#include <algorithm>
 
 namespace Spectrum {
 
@@ -270,9 +271,11 @@ void SimulationWorker::WorkerStart(void)
 void SimulationWorker::WorkerFinish(void)
 {
 // Print last trajectory
-// TODO possibly pad the number with zeros
    if(print_last_trajectory) {
-      std::string traj_name = "trajectory_rank" + std::to_string(mpi_config->work_comm_rank) + ".lines";
+      std::string rank_str = std::to_string(mpi_config->work_comm_rank);
+      std::string size_str = std::to_string(mpi_config->work_comm_size);
+      rank_str.insert(0, size_str.size() - rank_str.size(), '0');
+      std::string traj_name = "trajectory_rank_" + rank_str + ".lines";
       // trajectory->PrintTrajectory(traj_name, true, 0x01 | 0x02 | 0x04 | 0x08, 0, 1.0 / unit_time_fluid);
       trajectory->PrintCSV(traj_name, false, 1);
       trajectory->InterpretStatus();
@@ -773,10 +776,12 @@ void SimulationMaster::MasterFinish(void)
    PrintMessage(__FILE__, __LINE__, "Simulation completed", mpi_config->is_master);
 
 // Print last trajectory
-// TODO possibly pad the number with zeros
    if(print_last_trajectory && mpi_config->is_worker) {
-      std::string traj_name = "trajectory_rank" + std::to_string(mpi_config->work_comm_rank) + ".lines";
-      trajectory->PrintCSV(traj_name, false);
+      std::string rank_str = std::to_string(mpi_config->work_comm_rank);
+      std::string size_str = std::to_string(mpi_config->work_comm_size);
+      rank_str.insert(0, size_str.size() - rank_str.size(), '0');
+      std::string traj_name = "trajectory_rank_" + rank_str + ".lines";
+      trajectory->PrintCSV(traj_name, false, 1);
       trajectory->InterpretStatus();
    };
 

--- a/src/simulation.hh
+++ b/src/simulation.hh
@@ -20,7 +20,7 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 namespace Spectrum {
 
 //! Whether to print the last trajectory
-const bool print_last_trajectory = true;
+const bool print_last_trajectory = false;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 // SimulationWorker (base) class

--- a/src/trajectory_base.hh
+++ b/src/trajectory_base.hh
@@ -170,7 +170,7 @@ protected:
 //! Initial length of trajectory containers (persistent)
    unsigned int presize = 1;
 
-//! Particle's charge to mass ratio (persistent)
+//! Particle's charge (persistent)
    double q;
 
 //! Array of distribution objects (persistent)
@@ -190,6 +190,9 @@ protected:
 
 //! Array of momentum boundary condition objects (persistent)
    std::vector <std::unique_ptr <BoundaryBase> > bcond_m;
+
+//! Initial condition in time (persistent)
+   double icond_t = 0.0;
 
 //! Initial condition in space (persistent)
    std::unique_ptr <InitialBase> icond_s = nullptr;
@@ -459,6 +462,7 @@ inline void TrajectoryBase::ConnectDistribution(const std::shared_ptr<Distributi
 \author Vladimir Florinski
 \author Juan G Alonso Guzman
 \date 07/27/2022
+\param[in] distro index of which distribution to replace
 */
 inline void TrajectoryBase::ReplaceDistribution(int distro, const std::shared_ptr<DistributionBase> distribution_in)
 {
@@ -468,6 +472,7 @@ inline void TrajectoryBase::ReplaceDistribution(int distro, const std::shared_pt
 /*!
 \author Juan G Alonso Guzman
 \date 07/15/2022
+\param[in] distro index of which distribution to reset
 */
 inline void TrajectoryBase::DisconnectDistribution(int distro)
 {
@@ -533,7 +538,7 @@ inline void TrajectoryBase::StoreLocal(void)
 \date 06/12/2024
 \return Momentum in (p,mu,phi) coordinates
 */
-virtual GeoVector ConvertMomentum(void) const
+inline GeoVector TrajectoryBase::ConvertMomentum(void) const
 {
    return _mom;
 };

--- a/src/trajectory_guiding.cc
+++ b/src/trajectory_guiding.cc
@@ -66,17 +66,11 @@ void TrajectoryGuiding::ModifiedFields(void)
 try {
    double rL, rR;
 
-// Compute derived quantities from vector gradient of Bvec
-   gradBmag = _spdata.gradBmag();
-   curlbhat = (_spdata.curlB() - (gradBmag ^ _spdata.bhat)) / _spdata.Bmag;
-   dBmagdt =  _spdata.dBvecdt * _spdata.bhat;
-   dbhatdt = (_spdata.dBvecdt - (dBmagdt * _spdata.bhat)) / _spdata.Bmag;
-
 // Modified fields
    rL = LarmorRadius(_mom[0], _spdata.Bmag, specie);
    rR = LarmorRadius(_mom[2], _spdata.Bmag, specie);
-   Evec_star = _spdata.Evec - rR * _spdata.Bmag * dbhatdt / c_code - rL * _vel[0] * gradBmag / (2.0 * c_code);
-   Bvec_star = _spdata.Bvec + rR * _spdata.Bmag * curlbhat;
+   Evec_star = _spdata.Evec - rR * _spdata.Bmag * _spdata.dbhatdt() / c_code - rL * _vel[0] * _spdata.gradBmag / (2.0 * c_code);
+   Bvec_star = _spdata.Bvec + rR * _spdata.Bmag * _spdata.curlbhat();
 }
 
 catch(ExFieldError& exception) {
@@ -118,7 +112,7 @@ void TrajectoryGuiding::Slopes(GeoVector& slope_pos_istage, GeoVector& slope_mom
    slope_pos_istage = drift_vel;
 
 #if PPERP_METHOD == 1
-   slope_mom_istage[0] = _mom[0] / 2.0 / _spdata.Bmag * (dBmagdt + drift_vel * gradBmag);
+   slope_mom_istage[0] = 0.5 * _mom[0] / _spdata.Bmag * (_spdata.dBmagdt + drift_vel * _spdata.gradBmag);
 #else
    slope_mom_istage[0] = 0.0;
 #endif

--- a/src/trajectory_guiding.hh
+++ b/src/trajectory_guiding.hh
@@ -45,18 +45,6 @@ protected:
 //! Magnetic moment (transient)
    double mag_mom;
 
-//! Time derivative of |B| (transient)
-   double dBmagdt;
-
-//! Time derivative of b (transient)
-   GeoVector dbhatdt;
-
-//! Gradient of |B| (transient)
-   GeoVector gradBmag;
-
-//! Curl of b (transient)
-   GeoVector curlbhat;
-
 //! Modified electric field (transient)
    GeoVector Evec_star;
 
@@ -122,7 +110,7 @@ public:
 */
 inline GeoVector TrajectoryGuiding::ConvertMomentum(void) const
 {
-   return GeoVector(_mom.Norm(), _mom[2] / _mom.Norm(), 0.0);
+   return GeoVector(sqrt(Sqr(_mom[0])+Sqr(_mom[2])), _mom[2] / _mom.Norm(), 0.0);
 };
 
 

--- a/src/trajectory_lorentz.cc
+++ b/src/trajectory_lorentz.cc
@@ -7,7 +7,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 */
 
 #include "trajectory_lorentz.hh"
-#include <iostream>
 
 namespace Spectrum {
 

--- a/src/trajectory_parker.hh
+++ b/src/trajectory_parker.hh
@@ -13,11 +13,14 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 
 namespace Spectrum {
 
-//! Which stochastic method to use for diffusion, 0 = Euler, 1 = Milstein, 2 = RK2
+//! Which stochastic method to use for diffusion: 0 = Euler, 1 = Milstein, 2 = RK2
 #define TRAJ_PARKER_STOCHASTIC_METHOD_DIFF 0
 
 //! Flag to use gradient and curvature drifts in drift velocity calculation
-#define TRAJ_PARKER_USE_B_DRIFTS
+// #define TRAJ_PARKER_USE_B_DRIFTS
+
+//! Which method of computation to use for divK: 0 = using direct central FD, 1 = using _spdata.grad quantities
+#define TRAJ_PARKER_DIVK_METHOD 0
 
 //! Readable name of the TrajectoryParker class
 const std::string traj_name_parker = "TrajectoryParker";


### PR DESCRIPTION
In this major update, the numerical derivatives in both Background and Diffusion objects have been standardized to use central finite differences (2nd order) and use the particle's Larmor radius as the increment distance. This is acceptable since the derivative attributes of SpatialData objects are only used in transport models for which the scales of variation of the background are assumed to be much larger than the Larmor radius. In order to do this, the momentum magnitude has to be passed into "GetFields()". This change was propagated through the relevant files/functions. "ConvertMomentum()" was standarized as always returning momentum in (p, mu, phi) coordinates.

Features were added to the BackgroundSolarWind and derived classes related to the solar cycle and extent of the HCS, including a parameter to control the relative thickness of the peaks and troughs of the cycle.

In addition, an InitialTime condition was introduced for Trajectory objects to sync their background with respect to the "t0" in the Background classes in time dependent runs. This is the initial time for forward runs, and the final time for backward runs.

SpatialData now has a function to compute the time derivative of the magnetic unit vector called "dbhatdt()". This change was used in "Slopes()" for the TrajectoryFocused class and "ModifiedFields()" in the TrajectoryGuiding class.

Some bugs were also fixed, such as a missing "double t0" attribute in the BackgroundBase class or a stray "virtual" in "ConvertMomentum()" within background_base.hh. <algorithm> had to be (#)included into "simulation.hh" in order to use "std::max_element()". <iostream> was removed from packages that did not use it.