### PR TITLE
Updated SW with TS background

### DIFF
--- a/src/background_solarwind_termshock.cc
+++ b/src/background_solarwind_termshock.cc
@@ -66,7 +66,13 @@ void BackgroundSolarWindTermShock::SetupBackground(bool construct)
 void BackgroundSolarWindTermShock::ModifyUr(const double r, double &ur_mod)
 {
    if(r > r_TS) {
+#if SOLARWIND_TERMSHOCK_SPEED_EXPONENT == 1
+      if(r > r_TS + w_TS) ur_mod *= s_TS_inv * (r_TS + w_TS) / r;
+#elif SOLARWIND_TERMSHOCK_SPEED_EXPONENT == 2
       if(r > r_TS + w_TS) ur_mod *= s_TS_inv * Sqr((r_TS + w_TS) / r);
+#else
+      if(r > r_TS + w_TS) ur_mod *= s_TS_inv;
+#endif
       else ur_mod *= 1.0 + (s_TS_inv - 1.0) * (r - r_TS) / w_TS;
    };
 };
@@ -80,7 +86,13 @@ void BackgroundSolarWindTermShock::ModifyUr(const double r, double &ur_mod)
 double BackgroundSolarWindTermShock::TimeLag(const double r)
 {
    if(r < r_TS) return r / ur0;
-   else return (r_TS + (Cube(r) - Cube(r_TS)) / (3.0 * Sqr(r_TS))) / ur0;
+#if SOLARWIND_TERMSHOCK_SPEED_EXPONENT == 1
+   else return (r_TS + s_TS * (Sqr(r) - Sqr(r_TS)) / (2.0 * r_TS)) / ur0;
+#elif SOLARWIND_TERMSHOCK_SPEED_EXPONENT == 2
+   else return (r_TS + s_TS * (Cube(r) - Cube(r_TS)) / (3.0 * Sqr(r_TS))) / ur0;
+#else
+   else return (r_TS + s_TS * (r - r_TS)) / ur0;
+#endif
 };
 
 /*!

--- a/src/background_solarwind_termshock.hh
+++ b/src/background_solarwind_termshock.hh
@@ -14,6 +14,9 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 
 namespace Spectrum {
 
+//! Integer exponent of decrease of solar wind speed beyond the termination shock
+#define SOLARWIND_TERMSHOCK_SPEED_EXPONENT 2
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 // BackgroundSolarWindTermShock class declaration
 //----------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/distribution_other.cc
+++ b/src/distribution_other.cc
@@ -119,7 +119,8 @@ DistributionTimeUniform::DistributionTimeUniform(const DistributionTimeUniform& 
 
 /*!
 \author Vladimir Florinski
-\date 05/05/2022
+\author Juan G Alonso Guzman
+\date 08/11/2024
 \param[in] construct Whether called from a copy constructor or separately
 */
 void DistributionTimeUniform::SetupDistribution(bool construct)
@@ -136,7 +137,8 @@ void DistributionTimeUniform::SetupDistribution(bool construct)
 
 /*!
 \author Vladimir Florinski
-\date 05/05/2022
+\author Juan G Alonso Guzman
+\date 08/11/2024
 */
 void DistributionTimeUniform::EvaluateValue(void)
 {

--- a/src/distribution_other.hh
+++ b/src/distribution_other.hh
@@ -76,7 +76,7 @@ const std::string dist_name_time_uniform = "DistributionTimeUniform";
 \author Juan G Alonso Guzman
 
 Type: 1D time
-Parameters: (DistributionUniform)
+Parameters: (DistributionUniform), int val_time
 */
 class DistributionTimeUniform : public DistributionUniform<double> {
 


### PR DESCRIPTION
Updated BackgroundSolarWindTermShock to allow for different rates of decrease in plasma flow velocity after the termination shock. A constant (post-shock) velocity, a rate of 1 / r, and a rate of 1 / r^2 (incompressible), where r is the radial distance, are now supported. The documentation has been updated to reflect this change.