### PR TITLE
Major updates to GridBlock and CommunicationSite class families

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The 'common' directory contains fundamental classes and routines used throughout
 
 **Compiling and Running the Code**
 
-SPECTRUM was designed primarily for devices running popular Linux distros, such as Debian or Fedora, and uses the GNU Automake tool for compilation. Note that a C++ compiler (capable of interpreting c++21 or above), a properly installed MPI library (e.g. Open MPI or MPICH), and the GNU Scientic Library (GSL) of mathematical tools are pre-requisites for compiling and running SPECTRUM codes.
+SPECTRUM was designed primarily for devices running popular Linux distros, such as Debian or Fedora, and uses the GNU Automake tool for compilation. Note that a C++ compiler (capable of interpreting c++20 or above), a properly installed MPI library (e.g. Open MPI or MPICH), and the GNU Scientic Library (GSL) of mathematical tools are pre-requisites for compiling and running SPECTRUM codes.
 
 To configure the code from a fresh download navigate to the main SPECTRUM directory and execute the following commands in terminal:
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ The 'common' directory contains fundamental classes and routines used throughout
 
 **Compiling and Running the Code**
 
-SPECTRUM was designed primarily for devices running popular Linux distros, such as Debian or Fedora, and uses the GNU Automake tool for compilation. Note that a C++ compiler (c++17 or above), a properly installed MPI library (e.g. Open MPI or MPICH), and the GNU Scientic Library (GSL) of mathematical tools are pre-requisites for compiling and running SPECTRUM codes.
+SPECTRUM was designed primarily for devices running popular Linux distros, such as Debian or Fedora, and uses the GNU Automake tool for compilation. Note that a C++ compiler (capable of interpreting c++21 or above), a properly installed MPI library (e.g. Open MPI or MPICH), and the GNU Scientic Library (GSL) of mathematical tools are pre-requisites for compiling and running SPECTRUM codes.
 
 To configure the code from a fresh download navigate to the main SPECTRUM directory and execute the following commands in terminal:
 
-`autoreconf`
+```
+autoreconf
+automake --add-missing
+./configure <configure-options>
+```
 
-`automake --add-missing`
-
-`./configure <configure-options>`
-
-The `<configure-options>` are used to specify parameters such as which type of trajectory transport should be simulated or what integration method should be used. Consult the documentation ('SPECTRUM.pdf') for more details.
+The `<configure-options>` are used to specify parameters such as which type of trajectory transport should be simulated or what integration method should be used. Consult the documentation ('Documentation and Tutorial.pdf') for more details.

--- a/common/communication_site.hh
+++ b/common/communication_site.hh
@@ -1,0 +1,337 @@
+/*!
+\file communication_site.hh
+\brief Implements a generic MPI communication object
+\author Vladimir Florinski
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
+*/
+
+#ifndef SPECTRUM_COMMUNICATION_SITE_HH
+#define SPECTRUM_COMMUNICATION_SITE_HH
+
+#include <common/mpi_config.hh>
+
+#ifdef USE_MPI
+
+#include <cstring>
+#include <map>
+#include <vector>
+#include <algorithm>
+
+#ifdef GEO_DEBUG
+#include <common/print_warn.hh>
+#endif
+
+namespace Spectrum {
+
+// Example (n_parts=4):
+//          -------------------------               
+//          |  part 2   |  part 3   |     ranks_in:   11,  10,  11,  15
+//          |           |           |     labels_in: 381, 167, 254, 118
+//          | rank: 11  | rank: 15  |
+//          | bidx: 254 | bidx: 118 |     site_comm ranks: 11->0, 10->1, 15->2
+//          ------------+------------
+//          |  part 0   |  part 1   |     sendcounts: 2, 1, 1 (x buf_size)
+//          |           |           |     sdispls:    0, 2, 3 (x buf_size)
+//          | rank: 11  | rank: 10  |
+//          | bidx: 381 | bidx: 167 |     buffer_entry: 0->0, 1->2, 2->1, 3->3
+//          -------------------------                      ^           ^
+//                                                         |           |
+//                                                         ------------- contiguous
+
+/*!
+\brief A class representing a general MPI communication site
+\author Vladimir Florinski
+
+An object of this class contains an MPI communicator, a data buffer, and metadata to enable data exchange or reduction. The array "buffer" has "n_part" slots corresponding to each participant. Because a process could host multiple participants, "ExchangeSite" will aggregate those into larger slots in the array. The intended use is for the calling function to create an array of derived class objects, one per site. This is redundant because each process may only need access to a subset of all sites. However, MPI communicator creation routines must be called on all processes, and it is desirable to perform all such operations within the class. The unused sites will remain, but since the communicator and buffers are not allocated, the memory lost will be small.
+*/
+template <typename datatype>
+class CommunicationSite
+{
+protected:
+
+//! Index of this site
+   int site_index = -1;
+
+//! Number of participants (actual)
+   int n_parts = 0;
+
+//! Buffer size in units of "datatype". It is mainly stored for verification purposes (the class doesn't need it).
+   int buf_size = 0;
+
+//! Site communicator
+   MPI_Comm site_comm = MPI_COMM_NULL;
+
+//! Size of the site communicator
+   int site_comm_size = 0;
+
+//! MPI data type corresponding to the template type
+   MPI_Datatype mpi_datatype = MPI_DATATYPE_NULL;
+
+//! Shared buffer - should not be accessed directly by the caller, but via "buffer_entry"
+   datatype* buffer = nullptr;
+
+//! Send counts
+   int* sendcounts = nullptr;
+
+//! Displacements
+   int* sdispls = nullptr;
+
+//! Part index lookup map, accessed via labels
+   std::map<int, int> part_lookup;
+
+//! Entry points in the buffer, accessed via the part index
+   std::map<int, datatype*> buffer_entry;
+
+//! Default constructor - protected (this is a base class)
+   CommunicationSite(void) {};
+
+public:
+
+//! Copy constructor - deleted because each site must be unique due to MPI restrictions
+   CommunicationSite(const CommunicationSite& other) = delete;
+
+//! Move constructor
+   CommunicationSite(CommunicationSite&& other);
+
+//! Destructor
+   ~CommunicationSite();
+
+//! Assignment operator - deleted because we cannot have multiple copies of the MPI objects
+   CommunicationSite& operator =(const CommunicationSite& other) = delete;
+
+//! Retrieve the site index
+   int GetIndex(void) const {return n_parts;};
+
+//! Retrieve the part number
+   int GetPartCount(void) const {return n_parts;};
+
+//! Retrieve the size of the communicator
+   int GetCommSize(void) const {return site_comm_size;};
+
+//! Return the buffer entry point for this part
+   datatype* BufferAddress(int part) {return buffer_entry[part];};
+
+//! Return the part for this label
+   int PartOfLabel(int label) {return part_lookup[label];};
+
+//! Import lists of ranks and part labels
+   void SetUpProperties(int index_in, int n_parts_in, int buf_size_in, const int* ranks_in, const int* labels_in);
+
+#ifdef GEO_DEBUG
+//! Print the information about this site from the point of view of one rank
+   void PrintSiteInfo(int test_rank) const;
+#endif
+
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/16/2025
+\param[in] other Object to move into this
+*/
+template <typename datatype>
+inline CommunicationSite<datatype>::CommunicationSite(CommunicationSite<datatype>&& other)
+{
+   site_index = other.site_index;
+   n_parts = other.n_parts;
+   buf_size = other.buf_size;
+   other.site_index = -1;
+   other.n_parts = 0;
+   other.buf_size = 0;
+
+// Copy the communicator pointer and set the pointer in "other" to a null comm
+   site_comm = other.site_comm;
+   site_comm_size = other.site_comm_size;
+   other.site_comm = MPI_COMM_NULL;
+   other.site_comm_size = 0;
+
+// Copy the data type pointer and set the pointer in "other" to a null type
+   mpi_datatype = other.mpi_datatype;
+   other.mpi_datatype = MPI_DATATYPE_NULL;
+
+// Move the data buffer
+   buffer = other.buffer;
+   other.buffer = nullptr;
+
+// Move the count and displacement arrays
+   sendcounts = other.sendcounts;
+   sdispls = other.sdispls;
+   other.sendcounts = nullptr;
+   other.sdispls = nullptr;
+
+// Transfer the maps
+   part_lookup = std::move(other.part_lookup);
+   buffer_entry = std::move(other.buffer_entry);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/16/2025
+\param[in] index_in    Index of this exchange site
+\param[in] n_parts_in  Number of participants
+\param[in] buf_size_in Size of a single buffer in units of "datatype"
+\param[in] ranks_in    List of ranks (with possible repeats)
+\param[in] labels_in   List of labels
+*/
+template <typename datatype>
+inline void CommunicationSite<datatype>::SetUpProperties(int index_in, int n_parts_in, int buf_size_in, const int* ranks_in, const int* labels_in)
+{
+   int newrank;
+   std::vector<int> unique_ranks;
+   std::vector<std::vector<int>> part_lists;
+
+   site_index = index_in;
+   n_parts = n_parts_in;
+   buf_size = buf_size_in;
+
+// Generate a list of unique ranks
+   for (auto part = 0; part < n_parts; part++) {
+      newrank = ranks_in[part];
+
+// Generate the "parts_per_rank" table
+      auto it = std::find(unique_ranks.begin(), unique_ranks.end(), newrank);
+      if (it == unique_ranks.end()) {
+         unique_ranks.push_back(newrank);
+
+// This rank was not encountered before, so we create a new element in the part list vector for it
+         part_lists.emplace_back();
+         part_lists.back().push_back(part);
+      }
+      else {
+         part_lists[it - unique_ranks.begin()].push_back(part);
+      };
+   };
+
+// Create the site communicator. Every process must call "MPI_Comm_create", even if not in the group, so the code will not deadlock.
+   MPI_Group parent_group, site_group;
+   MPI_Comm_group(MPI_Config::glob_comm, &parent_group);
+   MPI_Group_incl(parent_group, unique_ranks.size(), unique_ranks.data(), &site_group);
+   MPI_Comm_create(MPI_Config::glob_comm, site_group, &site_comm);
+   MPI_Group_free(&site_group);
+   MPI_Group_free(&parent_group);
+
+// Not in the communicator - do not allocate storage
+   if (site_comm == MPI_COMM_NULL) return;
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+// Create the MPI datatype
+   MPI_Type_contiguous(sizeof(datatype), MPI_BYTE, &mpi_datatype);
+   MPI_Type_commit(&mpi_datatype);
+
+// Allocate the shared buffer
+   buffer = new datatype[buf_size_in * n_parts];
+
+// Calculate the counts and displacements for MPI
+   MPI_Comm_size(site_comm, &site_comm_size);
+   sendcounts = new int[site_comm_size];
+   sdispls = new int[site_comm_size];
+   for (auto rank = 0; rank < site_comm_size; rank++) {
+      sendcounts[rank] = part_lists[rank].size() * buf_size_in;
+      sdispls[rank] = (rank == 0 ? 0 : sdispls[rank - 1]) + sendcounts[rank - 1];
+   };
+
+// Create map to pointers in buffer space
+   int idx = 0;
+   for (auto rank = 0; rank < site_comm_size; rank++) {
+      for (auto ppr = 0; ppr < part_lists[rank].size(); ppr++) {
+         buffer_entry.insert(std::make_pair(part_lists[rank][ppr], &buffer[buf_size_in * idx]));
+         idx++;
+      };
+   };
+
+// Create a map to find a part based on the label
+   for (auto part = 0; part < n_parts; part++) {
+      part_lookup.insert(std::make_pair(labels_in[part], part));
+   };
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/16/2025
+*/
+template <typename datatype>
+inline CommunicationSite<datatype>::~CommunicationSite()
+{
+// Not safe to free a null MPI object
+   if (site_comm != MPI_COMM_NULL) MPI_Comm_free(&site_comm);
+   if (mpi_datatype != MPI_DATATYPE_NULL) MPI_Type_free(&mpi_datatype);
+
+// Always safe to delete a nullptr
+   delete[] sendcounts;
+   delete[] sdispls;
+   delete[] buffer;
+};
+
+#ifdef GEO_DEBUG
+
+/*!
+\author Vladimir Florinski
+\date 01/16/2025
+*/
+template <typename datatype>
+void CommunicationSite<datatype>::PrintSiteInfo(int test_rank) const
+{
+// Either the communicator wasn't set up or this process is not included
+   if (site_comm == MPI_COMM_NULL) return;
+   if (test_rank != MPI_Config::glob_comm_rank) return;
+
+   int datatype_size, n_parts_rank, part, label, my_site_rank;
+   datatype* buf_ptr;
+   MPI_Type_size(mpi_datatype, &datatype_size);
+   MPI_Comm_rank(site_comm, &my_site_rank);
+
+   std::cerr << "Printing information for site number " << site_index << std::endl;
+   std::cerr << "Site communicator size: " << site_comm_size << std::endl;
+   std::cerr << "Datatype size, in bytes: " << datatype_size << std::endl;
+   std::cerr << "Buffer size per part, in datatype units: " << buf_size << std::endl;
+   std::cerr << "My rank in the site communicator: " << my_site_rank << std::endl;
+
+   for (auto rank = 0; rank < site_comm_size; rank++) {
+      std::cerr << "Site rank" << std::setw(3) << rank << ":\n";
+
+// This rank has this many local parts
+      n_parts_rank = sendcounts[rank] / buf_size;
+      for (auto part_rank = 0; part_rank < n_parts_rank; part_rank++) {
+         std::cerr << "          Part";
+         buf_ptr = buffer + sdispls[rank] + part_rank * buf_size;
+
+// Find the key (part) for this address. A key not found indicates an error.
+         auto it1 = std::find_if(buffer_entry.begin(), buffer_entry.end(),
+                                 [buf_ptr](const std::pair<const int, datatype*>& p)
+                                 {
+                                    return p.second == buf_ptr;
+                                 });
+         if(it1 == buffer_entry.end()) std::cerr << "  -   Label  -\n";
+
+// Address was found, proceed to find the label
+         else {
+            part = it1->first;
+            std::cerr << std::setw(3) << part << "   Label";
+
+// Find the key (label) for this part
+            auto it2 = std::find_if(part_lookup.begin(), part_lookup.end(),
+                                    [part](const std::pair<const int, int>& p)
+                                    {
+                                       return p.second == part;
+                                    });
+
+// Print the label if the part was found
+            if(it2 == part_lookup.end()) std::cerr << "  -\n";
+            else {
+               label = it2->first;
+               std::cerr << std::setw(3) << label << std::endl;
+            };
+         };
+      };
+   };
+};
+
+#endif
+
+};
+
+#endif
+
+#endif

--- a/common/print_warn.hh
+++ b/common/print_warn.hh
@@ -16,14 +16,17 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 
 namespace Spectrum {
 
+//! Debug level
+#define GEO_DEBUG_LEVEL 3
+
 //! Comment character
 const char comment_char = '#';
 
 //! Color of error messages (red)
 const std::string err_color = "\033[31m";
 
-//! Color of informational messages (yellow)
-const std::string inf_color = "\033[33m";
+//! Color of informational messages (green)
+const std::string inf_color = "\033[32m";
 
 //! Color of normal messages (default)
 const std::string std_color = "\033[0m";

--- a/fluid/conservation_laws_gasdyn.cc
+++ b/fluid/conservation_laws_gasdyn.cc
@@ -1,0 +1,313 @@
+/*!
+\file conservation_laws_gasdyn.cc
+\brief Implements rules for compressible gas-dynamic equations
+\author Vladimir Florinski
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
+*/
+
+#include "common/physics.hh"
+#include "fluid/conservation_laws_gasdyn.hh"
+
+namespace Spectrum {
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Gasdyn::PrimitiveState methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] den_in Density
+\param[in] vel_in Velocity
+\param[in] pre_in Pressure
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::PrimitiveState::PrimitiveState(double den_in, const GeoVector&vel_in, double pre_in)
+{
+   den() = den_in;
+   vel() = vel_in;
+   pre() = pre_in;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] other Object to initialize from
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::PrimitiveState::PrimitiveState(const SimpleArray<double, CL_GASDYN_NVARS>& other)
+                                                  : SimpleArray<double, CL_GASDYN_NVARS>(other)
+{
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Fastest wave speed (sound)
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double Gasdyn<fluid>::PrimitiveState::FastestWave(void) const
+{
+   return SoundSpeed(den(), pre(), fluid);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Fastest normal wave speed (sound)
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double Gasdyn<fluid>::PrimitiveState::FastestWaveNormal(void) const
+{
+   return SoundSpeed(den(), pre(), fluid);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Vector of conserved variables
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::ConservedState Gasdyn<fluid>::PrimitiveState::ToConserved(void) const
+{
+   Gasdyn<fluid>::ConservedState cons;
+
+   cons.den() = den();
+   cons.mom() = den() * vel();
+   cons.enr() = Energy(den(), vel().Norm2(), 0.0, pre(), fluid);
+
+   return cons;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Flux vector
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::FluxFunction Gasdyn<fluid>::PrimitiveState::ToFlux(void) const
+{
+   double enr = Energy(den(), vel().Norm2(), 0.0, pre(), fluid);
+   Gasdyn<fluid>::FluxFunction flux;
+
+   flux.denf() = den() * vel()[0];
+   flux.momf() = den() * vel()[0] * vel() + pre() * gv_nx;
+   flux.enrf() = (enr + pre()) * vel()[0];
+
+   return flux;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Vector of primitive variables in a sonic state
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::PrimitiveState Gasdyn<fluid>::PrimitiveState::ToSonic(void) const
+{
+   double cs = Sound(den(), pre(), fluid);
+   double del_den = 2.0 * den() / (gamma_eos[fluid] + 1.0) * (vel()[0] / cs - 1.0);
+   double cs_star = vel()[0] - cs * del_den / den();
+
+   Gasdyn<fluid>::PrimitiveState prim;
+   
+   prim.den() = den() + del_den;
+   prim.vel()[0] = cs_star;
+   prim.vel()[1] = vel()[1];
+   prim.vel()[2] = vel()[2];
+   prim.pre() = prim.den() * Sqr(cs_star) / gamma_eos[fluid];
+   return prim;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void Gasdyn<fluid>::PrimitiveState::Invert(void)
+{
+   vel()[0] = -vel()[0];
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Gasdyn::ConservedState methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] den_in Density
+\param[in] mom_in Momentum
+\param[in] enr_in Energy
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::ConservedState::ConservedState(double den_in, const GeoVector& mom_in, double enr_in)
+{
+   den() = den_in;
+   mom() = mom_in;
+   enr() = enr_in;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] other Object to initialize from
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::ConservedState::ConservedState(const SimpleArray<double, CL_GASDYN_NVARS>& other)
+                                                  : SimpleArray<double, CL_GASDYN_NVARS>(other)
+{
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Fastest wave speed (sound)
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double Gasdyn<fluid>::ConservedState::FastestWave(void) const
+{
+   GeoVector vel = mom() / den();
+   double pre = Pressure(den(), vel.Norm2(), 0.0, enr(), fluid);
+   return SoundSpeed(den(), pre, fluid);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Fastest normal wave speed (sound)
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double Gasdyn<fluid>::ConservedState::FastestWaveNormal(void) const
+{
+   GeoVector vel = mom() / den();
+   double pre = Pressure(den(), vel.Norm2(), 0.0, enr(), fluid);
+   return SoundSpeed(den(), pre, fluid);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Vector of primitive variables
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::PrimitiveState Gasdyn<fluid>::ConservedState::ToPrimitive(void) const
+{
+   Gasdyn<fluid>::PrimitiveState prim;
+
+   prim.den() = den();
+   prim.vel() = mom() / den();
+   prim.pre() = Pressure(den(), prim.vel().Norm2(), 0.0, enr(), fluid);
+
+   return prim;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Flux vector
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::FluxFunction Gasdyn<fluid>::ConservedState::ToFlux(void) const
+{
+   double pre = Pressure(den(), mom().Norm2() / Sqr(den()), 0.0, enr(), fluid);
+
+   Gasdyn<fluid>::FluxFunction flux;
+   flux.denf() = mom()[0];
+   flux.momf() = mom()[0] * mom() / den() + pre * gv_nx;
+   flux.enrf() = (enr() + pre) * mom()[0] / den();
+
+   return flux;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Gas pressure
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double Gasdyn<fluid>::ConservedState::GetPressure(void) const
+{
+   return Pressure(den(), mom().Norm2() / Sqr(den()), 0.0, enr(), fluid);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] flux Flux vector
+\param[in] S1   First wave speed
+\param[in] S2   Second wave speed
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void Gasdyn<fluid>::ConservedState::FixMomentum(Gasdyn<fluid>::FluxFunction& flux, double S1, double S2)
+{
+   mom()[1] = flux.mom()[1] / (S1 - S2);
+   mom()[2] = flux.mom()[2] / (S1 - S2);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] flux Flux vector
+\param[in] S1   First wave speed
+\param[in] S2   Second wave speed
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void Gasdyn<fluid>::ConservedState::FixEnergy(Gasdyn<fluid>::FluxFunction& flux, double S1, double S2)
+{
+   double pre_total = S1 * mom()[0] - flux.mom()[0];
+   enr() = (flux.enr() + pre_total * S2) / (S1 - S2);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void Gasdyn<fluid>::ConservedState::Invert(void)
+{
+   mom()[0] = -mom()[0];
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Gasdyn::FluxFunction methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] denf_in Density flux
+\param[in] momf_in Momentum flux
+\param[in] enrf_in Energy flux
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::FluxFunction::FluxFunction(double denf_in, const GeoVector& momf_in, double enrf_in)
+{
+   denf() = denf_in;
+   momf() = momf_in;
+   enrf() = enrf_in;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] other Object to initialize from
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC Gasdyn<fluid>::FluxFunction::FluxFunction(const SimpleArray<double, CL_GASDYN_NVARS>& other)
+                                                : SimpleArray<double, CL_GASDYN_NVARS>(other)
+{
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void Gasdyn<fluid>::FluxFunction::Invert(void)
+{
+   momf()[0] = -momf()[0];
+};
+
+};

--- a/fluid/conservation_laws_gasdyn.hh
+++ b/fluid/conservation_laws_gasdyn.hh
@@ -9,533 +9,187 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 #ifndef SPECTRUM_CONSERVATION_LAWS_GASDYN_HH
 #define SPECTRUM_CONSERVATION_LAWS_GASDYN_HH
 
-#include "common/physics.hh"
+#include "common/vectors.hh"
 
 namespace Spectrum {
 
 //! Number of fluid variables (DEN,VELx3,PRE)
 #define CL_GASDYN_NVARS 5
 
-//! Total number of variables
-#define CL_GASDYN_TOTAL (CL_GASDYN_NVARS + n_ind)
-
-template <int fluid, int n_ind> struct PrimitiveStateGasdyn;
-template <int fluid, int n_ind> struct ConservedStateGasdyn;
-template <int fluid, int n_ind> struct FluxFunctionGasdyn;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// PrimitiveStateGasdyn class declaration
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-template <int fluid, int n_ind>
-struct PrimitiveStateGasdyn : public SimpleArray<double, CL_GASDYN_TOTAL>
+/*!
+\brief Codifies physics of compressible gas dynamics
+\author Vladimir Florinski
+*/
+template <int fluid>
+class Gasdyn
 {
-   using SimpleArray<double, CL_GASDYN_TOTAL>::data;
+public:
 
-//! Alias for density (RO)
-   const double& den(void) const {return data[0];};
+   struct ConservedState;
+   struct FluxFunction;
 
-//! Alias for density (RW)
-   double& den(void) {return data[0];};
-
-//! Alias for velocity (RO)
-   const GeoVector& vel(void) const {return (const GeoVector&)data[1];};
-
-//! Alias for velocity (RW)
-   GeoVector& vel(void) {return (GeoVector&)data[1];};
-
-//! Alias for pressure (RO)
-   const double& pre(void) const {return data[4];};
-
-//! Alias for pressure (RW)
-   double& pre(void) {return data[4];};
+//! A trait to be used in template specializations
+   static constexpr bool is_cons_law_active = true;
 
 //! Return the "fluid" template parameter
-   SPECTRUM_DEVICE_FUNC int Fluid(void) const {return fluid;};
+   SPECTRUM_DEVICE_FUNC static constexpr int Fluid(void) {return fluid;};
 
-//! Return the "n_ind" template parameter
-   SPECTRUM_DEVICE_FUNC int Nind(void) const {return n_ind;};
-
-//! Return the number of main variables
-   SPECTRUM_DEVICE_FUNC int Nmain(void) const {return CL_GASDYN_NVARS;};
-
-//! Default constructor
-   SPECTRUM_DEVICE_FUNC PrimitiveStateGasdyn(void) = default;
-
-//! Constructor from components
-   SPECTRUM_DEVICE_FUNC PrimitiveStateGasdyn(double den_in, const GeoVector& vel_in, double pre_in, double* ind_in);
-
-//! Constructor from the base class
-   SPECTRUM_DEVICE_FUNC PrimitiveStateGasdyn(const SimpleArray<double, CL_GASDYN_TOTAL>& other);
-
-//! Calculate the fastest wave speed
-   SPECTRUM_DEVICE_FUNC double FastestWave(void) const;
-
-//! Calculate the fastest normal wave speed
-   SPECTRUM_DEVICE_FUNC double FastestWaveNormal(void) const;
-
-//! Calculate conserved state
-   SPECTRUM_DEVICE_FUNC ConservedStateGasdyn<fluid, n_ind> ToConserved(bool ind_ok) const;
-
-//! Calculate flux function
-   SPECTRUM_DEVICE_FUNC FluxFunctionGasdyn<fluid, n_ind> ToFlux(bool ind_ok) const;
-
-//! Calculate sonic state
-   SPECTRUM_DEVICE_FUNC PrimitiveStateGasdyn<fluid, n_ind> ToSonic(bool ind_ok) const;
-
-//! Invert vector variables
-   SPECTRUM_DEVICE_FUNC void Invert(void);
-};
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// ConservedStateGasdyn class declaration
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-template <int fluid, int n_ind>
-struct ConservedStateGasdyn : public SimpleArray<double, CL_GASDYN_TOTAL>
-{
-   using SimpleArray<double, CL_GASDYN_TOTAL>::data;
-
-//! Alias for density (RO)
-   const double& den(void) const {return data[0];};
-
-//! Alias for density (RW)
-   double& den(void) {return data[0];};
-
-//! Alias for momentum (RO)
-   const GeoVector& mom(void) const {return (const GeoVector&)data[1];};
-
-//! Alias for momentum (RW)
-   GeoVector& mom(void) {return (GeoVector&)data[1];};
-
-//! Alias for energy (RO)
-   const double& enr(void) const {return data[4];};
-
-//! Alias for energy (RW)
-   double& enr(void) {return data[4];};
-
-//! Return the "fluid" template parameter
-   SPECTRUM_DEVICE_FUNC int Fluid(void) const {return fluid;};
-
-//! Return the "n_ind" template parameter
-   SPECTRUM_DEVICE_FUNC int Nind(void) const {return n_ind;};
-
-//! Return the number of main variables
-   SPECTRUM_DEVICE_FUNC int Nmain(void) const {return CL_GASDYN_NVARS;};
-
-//! Default constructor
-   SPECTRUM_DEVICE_FUNC ConservedStateGasdyn(void) = default;
-
-//! Constructor from components
-   SPECTRUM_DEVICE_FUNC ConservedStateGasdyn(double den_in, const GeoVector& mom_in, double enr_in, double* ind_in);
-
-//! Constructor from the base class
-   SPECTRUM_DEVICE_FUNC ConservedStateGasdyn(const SimpleArray<double, CL_GASDYN_TOTAL>& other);
-
-//! Calculate the fastest wave speed
-   SPECTRUM_DEVICE_FUNC double FastestWave(void) const;
-
-//! Calculate the fastest normal wave speed
-   SPECTRUM_DEVICE_FUNC double FastestWaveNormal(void) const;
-
-//! Calculate primitive state
-   SPECTRUM_DEVICE_FUNC PrimitiveStateGasdyn<fluid, n_ind> ToPrimitive(bool ind_ok) const;
-
-//! Calculate flux function
-   SPECTRUM_DEVICE_FUNC FluxFunctionGasdyn<fluid, n_ind> ToFlux(bool ind_ok) const;
-
-//! Calculate _gas_ pressure
-   SPECTRUM_DEVICE_FUNC double GetPressure(void) const;
-
-//! Calculate y and z components of momentum from the externally provided flux in a moving frame
-   SPECTRUM_DEVICE_FUNC void FixMomentum(FluxFunctionGasdyn<fluid, n_ind>& flux, double S1, double S2);
-
-//! Calculate energy from the externally provided flux in a moving frame
-   SPECTRUM_DEVICE_FUNC void FixEnergy(FluxFunctionGasdyn<fluid, n_ind>& flux, double S1, double S2);
-
-//! Invert vector variables
-   SPECTRUM_DEVICE_FUNC void Invert(void);
-};
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// FluxFunctionGasdyn class declaration
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-template <int fluid, int n_ind>
-struct FluxFunctionGasdyn : public SimpleArray<double, CL_GASDYN_TOTAL>
-{
-   using SimpleArray<double, CL_GASDYN_TOTAL>::data;
-
-//! Alias for density flux (RO)
-   const double& denf(void) const {return data[0];};
-
-//! Alias for density flux (RW)
-   double& denf(void) {return data[0];};
-
-//! Alias for momentum flux (RO)
-   const GeoVector& momf(void) const {return (const GeoVector&)data[1];};
-
-//! Alias for momentum flux (RW)
-   GeoVector& momf(void) {return (GeoVector&)data[1];};
-
-//! Alias for energy flux (RO)
-   const double& enrf(void) const {return data[4];};
-
-//! Alias for energy flux (RW)
-   double& enrf(void) {return data[4];};
-
-//! Return the "fluid" template parameter
-   SPECTRUM_DEVICE_FUNC int Fluid(void) const {return fluid;};
-
-//! Return the "n_ind" template parameter
-   SPECTRUM_DEVICE_FUNC int Nind(void) const {return n_ind;};
-
-//! Return the number of main variables
-   SPECTRUM_DEVICE_FUNC int Nmain(void) const {return CL_GASDYN_NVARS;};
-
-//! Default constructor
-   SPECTRUM_DEVICE_FUNC FluxFunctionGasdyn(void) = default;
-
-//! Constructor from components
-   SPECTRUM_DEVICE_FUNC FluxFunctionGasdyn(double denf_in, const GeoVector& momf_in, double enrf_in, double* indf_in);
-
-//! Constructor from the base class
-   SPECTRUM_DEVICE_FUNC FluxFunctionGasdyn(const SimpleArray<double, CL_GASDYN_TOTAL>& other);
-
-//! Invert vector variables
-   SPECTRUM_DEVICE_FUNC void Invert(void);
-};
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// PrimitiveStateGasdyn inline methods
-//----------------------------------------------------------------------------------------------------------------------------------------------------
+//! Return the number of variables
+   SPECTRUM_DEVICE_FUNC static constexpr int Nvars(void) {return CL_GASDYN_NVARS;};
 
 /*!
+\brief Codifies physics of compressible gas dynamics for primitive variables
 \author Vladimir Florinski
-\date 03/15/2024
-\param[in] den_in Density
-\param[in] vel_in Velocity
-\param[in] pre_in Pressure
-\param[in] ind_in Indicator variables
 */
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline PrimitiveStateGasdyn<fluid, n_ind>::PrimitiveStateGasdyn(double den_in, const GeoVector& vel_in,
-                                                                                     double pre_in, double* ind_in)
-{
-   den() = den_in;
-   vel() = vel_in;
-   pre() = pre_in;
-   if(n_ind != 0) memcpy(data + CL_GASDYN_NVARS, ind_in, n_ind * sizeof(double));
-};
+   struct PrimitiveState : public SimpleArray<double, CL_GASDYN_NVARS>
+   {
+      using SimpleArray<double, CL_GASDYN_NVARS>::data;
 
-/*!
-\author Vladimir Florinski
-\date 03/14/2024
-\param[in] other Object to initialize from
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline PrimitiveStateGasdyn<fluid, n_ind>::PrimitiveStateGasdyn(const SimpleArray<double, CL_GASDYN_TOTAL>& other)
-   : SimpleArray<double, CL_GASDYN_TOTAL>(other)
-{
-};
+   //! Alias for density (RO)
+      const double& den(void) const {return data[0];};
 
-/*!
-\author Vladimir Florinski
-\date 03/16/2024
-\return Fastest wave speed (sound)
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double PrimitiveStateGasdyn<fluid, n_ind>::FastestWave(void) const
-{
-   return SoundSpeed(den(), pre(), fluid);
-};
+   //! Alias for density (RW)
+      double& den(void) {return data[0];};
 
-/*!
-\author Vladimir Florinski
-\date 03/16/2024
-\return Fastest normal wave speed (sound)
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double PrimitiveStateGasdyn<fluid, n_ind>::FastestWaveNormal(void) const
-{
-   return SoundSpeed(den(), pre(), fluid);
-};
+   //! Alias for velocity (RO)
+      const GeoVector& vel(void) const {return (const GeoVector&)data[1];};
 
-/*!
-\author Vladimir Florinski
-\date 03/06/2024
-\return Vector of conserved variables
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline ConservedStateGasdyn<fluid, n_ind> PrimitiveStateGasdyn<fluid, n_ind>::ToConserved(bool ind_ok) const
-{
-   ConservedStateGasdyn<fluid, n_ind> cons;
+   //! Alias for velocity (RW)
+      GeoVector& vel(void) {return (GeoVector&)data[1];};
 
-   cons.den() = den();
-   cons.mom() = den() * vel();
-   cons.enr() = Energy(den(), vel().Norm2(), 0.0, pre(), fluid);
+   //! Alias for pressure (RO)
+      const double& pre(void) const {return data[4];};
 
-// Optionally convert the indicator variables
-   if(ind_ok) {
-      for(auto i = CL_GASDYN_NVARS; i < CL_GASDYN_NVARS + n_ind; i++) {
-         cons.data[i] = den() * data[i];
-      };
+   //! Alias for pressure (RW)
+      double& pre(void) {return data[4];};
+
+   //! Default constructor
+      SPECTRUM_DEVICE_FUNC PrimitiveState(void) = default;
+
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC PrimitiveState(double den_in, const GeoVector& vel_in, double pre_in);
+
+   //! Constructor from SimpleArray
+      SPECTRUM_DEVICE_FUNC PrimitiveState(const SimpleArray<double, CL_GASDYN_NVARS>& other);
+
+   //! Calculate the fastest wave speed
+      SPECTRUM_DEVICE_FUNC double FastestWave(void) const;
+
+   //! Calculate the fastest normal wave speed
+      SPECTRUM_DEVICE_FUNC double FastestWaveNormal(void) const;
+
+   //! Calculate conserved state
+      SPECTRUM_DEVICE_FUNC ConservedState ToConserved(void) const;
+
+   //! Calculate flux function
+      SPECTRUM_DEVICE_FUNC FluxFunction ToFlux(void) const;
+
+   //! Calculate sonic state
+      SPECTRUM_DEVICE_FUNC PrimitiveState ToSonic(void) const;
+
+   //! Invert vector variables about the x-axis
+      SPECTRUM_DEVICE_FUNC void Invert(void);
    };
-   return cons;
-};
 
 /*!
+\brief Codifies physics of compressible gas dynamics for conserved variables
 \author Vladimir Florinski
-\date 03/06/2024
-\return Flux vector
 */
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline FluxFunctionGasdyn<fluid, n_ind> PrimitiveStateGasdyn<fluid, n_ind>::ToFlux(bool ind_ok) const
-{
-   double enr = Energy(den(), vel().Norm2(), 0.0, pre(), fluid);
-   FluxFunctionGasdyn<fluid, n_ind> flux;
+   struct ConservedState : public SimpleArray<double, CL_GASDYN_NVARS>
+   {
+      using SimpleArray<double, CL_GASDYN_NVARS>::data;
 
-   flux.denf() = den() * vel()[0];
-   flux.momf() = den() * vel()[0] * vel() + pre() * gv_nx;
-   flux.enrf() = (enr + pre()) * vel()[0];
+   //! Alias for density (RO)
+      const double& den(void) const {return data[0];};
 
-// Optionally convert the indicator variables
-   if(ind_ok) {
-      for(auto i = CL_GASDYN_NVARS; i < CL_GASDYN_NVARS + n_ind; i++) {
-         flux.data[i] = den() * data[i] * vel()[0];
-      };
+   //! Alias for density (RW)
+      double& den(void) {return data[0];};
+
+   //! Alias for momentum (RO)
+      const GeoVector& mom(void) const {return (const GeoVector&)data[1];};
+
+   //! Alias for momentum (RW)
+      GeoVector& mom(void) {return (GeoVector&)data[1];};
+
+   //! Alias for energy (RO)
+      const double& enr(void) const {return data[4];};
+
+   //! Alias for energy (RW)
+      double& enr(void) {return data[4];};
+
+   //! Default constructor
+      SPECTRUM_DEVICE_FUNC ConservedState(void) = default;
+
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC ConservedState(double den_in, const GeoVector& mom_in, double enr_in);
+
+   //! Constructor from SimpleArray
+      SPECTRUM_DEVICE_FUNC ConservedState(const SimpleArray<double, CL_GASDYN_NVARS>& other);
+
+   //! Calculate the fastest wave speed
+      SPECTRUM_DEVICE_FUNC double FastestWave(void) const;
+
+   //! Calculate the fastest normal wave speed
+      SPECTRUM_DEVICE_FUNC double FastestWaveNormal(void) const;
+
+   //! Calculate primitive state
+      SPECTRUM_DEVICE_FUNC PrimitiveState ToPrimitive(void) const;
+
+   //! Calculate flux function
+      SPECTRUM_DEVICE_FUNC FluxFunction ToFlux(void) const;
+
+   //! Calculate _gas_ pressure
+      SPECTRUM_DEVICE_FUNC double GetPressure(void) const;
+
+   //! Calculate y and z components of momentum from the externally provided flux in a moving frame
+      SPECTRUM_DEVICE_FUNC void FixMomentum(FluxFunction& flux, double S1, double S2);
+
+   //! Calculate energy from the externally provided flux in a moving frame
+      SPECTRUM_DEVICE_FUNC void FixEnergy(FluxFunction& flux, double S1, double S2);
+
+   //! Invert vector variables about the x-axis
+      SPECTRUM_DEVICE_FUNC void Invert(void);
    };
-   return flux;
-};
 
 /*!
+\brief Codifies physics of compressible gas dynamics for the fluxes
 \author Vladimir Florinski
-\date 04/10/2024
-\return Vector of primitive variables in a sonic state
 */
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC PrimitiveStateGasdyn<fluid, n_ind> PrimitiveStateGasdyn<fluid, n_ind>::ToSonic(bool ind_ok) const
-{
-   double cs = Sound(den(), pre(), fluid);
-   double gamm1 = gamma_eos[fluid] - 1.0;
-   double gamp1 = gamma_eos[fluid] + 1.0;
-   double del_den = 2.8 * den() / gamp1 * (vel()[0] / cs - 1.0);
-   double cs_star = cs * (1.0 + 0.5 * gamm1 * cs * del_den / den());
-   PrimitiveStateGasdyn<fluid, n_ind> prim;
-   
-   prim.den() = den() + del_den;
-   prim.vel()[0] = vel()[0] - cs * del_den / den();
-   prim.vel()[1] = vel()[1];
-   prim.vel()[2] = vel()[2];
-   prim.pre() = prim.den() * Sqr(cs_star) / gamma_eos[fluid];
-};
+   struct FluxFunction : public SimpleArray<double, CL_GASDYN_NVARS>
+   {
+      using SimpleArray<double, CL_GASDYN_NVARS>::data;
 
-/*!
-\author Vladimir Florinski
-\date 04/09/2024
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void PrimitiveStateGasdyn<fluid, n_ind>::Invert(void)
-{
-   vel()[0] = -vel()[0];
-};
+   //! Alias for density flux (RO)
+      const double& denf(void) const {return data[0];};
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// ConservedStateGasdyn inline methods
-//----------------------------------------------------------------------------------------------------------------------------------------------------
+   //! Alias for density flux (RW)
+      double& denf(void) {return data[0];};
 
-/*!
-\author Vladimir Florinski
-\date 03/14/2024
-\param[in] den_in Density
-\param[in] mom_in Momentum
-\param[in] enr_in Energy
-\param[in] ind_in Indicator variables
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline ConservedStateGasdyn<fluid, n_ind>::ConservedStateGasdyn(double den_in, const GeoVector& mom_in,
-                                                                                     double enr_in, double* ind_in)
-{
-   den() = den_in;
-   mom() = mom_in;
-   enr() = enr_in;
-   if(n_ind != 0) memcpy(data + CL_GASDYN_NVARS, ind_in, n_ind * sizeof(double));
-};
+   //! Alias for momentum flux (RO)
+      const GeoVector& momf(void) const {return (const GeoVector&)data[1];};
 
-/*!
-\author Vladimir Florinski
-\date 03/14/2024
-\param[in] other Object to initialize from
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline ConservedStateGasdyn<fluid, n_ind>::ConservedStateGasdyn(const SimpleArray<double, CL_GASDYN_TOTAL>& other)
-   : SimpleArray<double, CL_GASDYN_TOTAL>(other)
-{
-};
+   //! Alias for momentum flux (RW)
+      GeoVector& momf(void) {return (GeoVector&)data[1];};
 
-/*!
-\author Vladimir Florinski
-\date 03/16/2024
-\return Fastest wave speed (sound)
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double ConservedStateGasdyn<fluid, n_ind>::FastestWave(void) const
-{
-   GeoVector vel = mom() / den();
-   double pre = Pressure(den(), vel.Norm2(), 0.0, enr(), fluid);
-   return SoundSpeed(den(), pre, fluid);
-};
+   //! Alias for energy flux (RO)
+      const double& enrf(void) const {return data[4];};
 
-/*!
-\author Vladimir Florinski
-\date 03/16/2024
-\return Fastest normal wave speed (sound)
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double ConservedStateGasdyn<fluid, n_ind>::FastestWaveNormal(void) const
-{
-   GeoVector vel = mom() / den();
-   double pre = Pressure(den(), vel.Norm2(), 0.0, enr(), fluid);
-   return SoundSpeed(den(), pre, fluid);
-};
+   //! Alias for energy flux (RW)
+      double& enrf(void) {return data[4];};
 
-/*!
-\author Vladimir Florinski
-\date 03/06/2024
-\return Vector of primitive variables
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline PrimitiveStateGasdyn<fluid, n_ind> ConservedStateGasdyn<fluid, n_ind>::ToPrimitive(bool ind_ok) const
-{
-   PrimitiveStateGasdyn<fluid, n_ind> prim;
+   //! Default constructor
+      SPECTRUM_DEVICE_FUNC FluxFunction(void) = default;
 
-   prim.den() = den();
-   prim.vel() = mom() / den();
-   prim.pre() = Pressure(den(), prim.vel().Norm2(), 0.0, enr(), fluid);
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC FluxFunction(double denf_in, const GeoVector& momf_in, double enrf_in);
 
-// Optionally convert the indicator variables
-   if(ind_ok) {
-      for(auto i = CL_GASDYN_NVARS; i < CL_GASDYN_NVARS + n_ind; i++) {
-         prim.data[i] = data[i] / den();
-      };
+   //! Constructor from SimpleArray
+      SPECTRUM_DEVICE_FUNC FluxFunction(const SimpleArray<double, CL_GASDYN_NVARS>& other);
+
+   //! Invert vector variables about the x-axis
+      SPECTRUM_DEVICE_FUNC void Invert(void);
    };
-   return prim;
-};
 
-/*!
-\author Vladimir Florinski
-\date 03/06/2024
-\return Flux vector
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline FluxFunctionGasdyn<fluid, n_ind> ConservedStateGasdyn<fluid, n_ind>::ToFlux(bool ind_ok) const
-{
-   double pre = Pressure(den(), mom().Norm2() / Sqr(den()), 0.0, enr(), fluid);
-
-   FluxFunctionGasdyn<fluid, n_ind> flux;
-   flux.denf() = mom()[0];
-   flux.momf() = mom()[0] * mom() / den() + pre * gv_nx;
-   flux.enrf() = (enr() + pre) * mom()[0] / den();
-
-// Optionally convert the indicator variables
-   if(ind_ok) {
-      for(auto i = CL_GASDYN_NVARS; i < CL_GASDYN_NVARS + n_ind; i++) {
-         flux.data[i] = data[i] * mom()[0];
-      };
-   };
-   return flux;
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/20/2024
-\return Gas pressure
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double ConservedStateGasdyn<fluid, n_ind>::GetPressure(void) const
-{
-   return Pressure(den(), mom().Norm2() / Sqr(den()), 0.0, enr(), fluid);
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/18/2024
-\param[in] flux Flux vector
-\param[in] S1   First wave speed
-\param[in] S2   Second wave speed
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void ConservedStateGasdyn<fluid, n_ind>::FixMomentum(FluxFunctionGasdyn<fluid, n_ind>& flux, double S1, double S2)
-{
-   mom()[1] = flux.mom()[1] / (S1 - S2);
-   mom()[2] = flux.mom()[2] / (S1 - S2);
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/20/2024
-\param[in] flux Flux vector
-\param[in] S1   First wave speed
-\param[in] S2   Second wave speed
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void ConservedStateGasdyn<fluid, n_ind>::FixEnergy(FluxFunctionGasdyn<fluid, n_ind>& flux, double S1, double S2)
-{
-   double pre_total = S1 * mom()[0] - flux.mom()[0];
-   enr() = (flux.enr() + pre_total * S2) / (S1 - S2);
-};
-
-/*!
-\author Vladimir Florinski
-\date 04/09/2024
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void ConservedStateGasdyn<fluid, n_ind>::Invert(void)
-{
-   mom()[0] = -mom()[0];
-};
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// FluxFunctionGasdyn inline methods
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-/*!
-\author Vladimir Florinski
-\date 03/15/2024
-\param[in] denf_in Density flux
-\param[in] momf_in Momentum flux
-\param[in] enrf_in Energy flux
-\param[in] indf_in Indicator variables flux
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline FluxFunctionGasdyn<fluid, n_ind>::FluxFunctionGasdyn(double denf_in, const GeoVector& momf_in,
-                                                                                 double enrf_in, double* indf_in)
-{
-   denf() = denf_in;
-   momf() = momf_in;
-   enrf() = enrf_in;
-   if(n_ind != 0) memcpy(data + CL_GASDYN_NVARS, indf_in, n_ind * sizeof(double));
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/14/2024
-\param[in] other Object to initialize from
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline FluxFunctionGasdyn<fluid, n_ind>::FluxFunctionGasdyn(const SimpleArray<double, CL_GASDYN_TOTAL>& other)
-   : SimpleArray<double, CL_GASDYN_TOTAL>(other)
-{
-};
-
-/*!
-\author Vladimir Florinski
-\date 04/09/2024
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void FluxFunctionGasdyn<fluid, n_ind>::Invert(void)
-{
-   momf()[0] = -momf()[0];
 };
 
 };

--- a/fluid/conservation_laws_mhd.cc
+++ b/fluid/conservation_laws_mhd.cc
@@ -1,0 +1,422 @@
+/*!
+\file conservation_laws_mhd.cc
+\brief Implements rules for ideal MHD equations
+\author Vladimir Florinski
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
+*/
+
+#include "common/physics.hh"
+#include "fluid/conservation_laws_mhd.hh"
+
+namespace Spectrum {
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// MHD::PrimitiveState methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] den_in Density
+\param[in] vel_in Velocity
+\param[in] pre_in Pressure
+\param[in] mag_in Magnetic field
+\param[in] glm_in Largange multiplier
+*/
+template <int fluid>
+#ifdef CL_MHD_GLM
+SPECTRUM_DEVICE_FUNC MHD<fluid>::PrimitiveState::PrimitiveState(double den_in, const GeoVector& vel_in, double pre_in, const GeoVector& mag_in, double glm_in)
+#else
+SPECTRUM_DEVICE_FUNC MHD<fluid>::PrimitiveState::PrimitiveState(double den_in, const GeoVector& vel_in, double pre_in, const GeoVector& mag_in)
+#endif
+{
+   den() = den_in;
+   vel() = vel_in;
+   pre() = pre_in;
+   mag() = mag_in;
+
+#ifdef CL_MHD_GLM
+   glm() = glm_in;
+#endif
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] other Object to initialize from
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC MHD<fluid>::PrimitiveState::PrimitiveState(const SimpleArray<double, CL_MHD_NVARS>& other)
+                                               : SimpleArray<double, CL_MHD_NVARS>(other)
+{
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Fastest wave speed (max fast with GLM safety)
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double MHD<fluid>::PrimitiveState::FastestWave(void) const
+{
+   double Va2 = Alfven2(den(), mag().Norm2());
+   double Cs2 = Sound2(den(), pre(), fluid);
+
+// FIXME decide where to use "CL_MHD_GLMSAFETY"
+//#ifdef CL_MHD_GLM
+   return sqrt(Va2 + Cs2);
+//#else
+//   return CL_MHD_GLMSAFETY * sqrt(Va2 + Cs2);
+//#endif
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Fastest normal wave speed (fast_n)
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double MHD<fluid>::PrimitiveState::FastestWaveNormal(void) const
+{
+   double Va2 = Alfven2(den(), mag().Norm2());
+   double Vax2 = Alfven2(den(), Sqr(mag()[0]));
+   double Cs2 = Sound2(den(), pre(), fluid);
+
+   return FastMagnetosonicSpeed(Va2, Vax2, Cs2);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Vector of conserved variables
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC MHD<fluid>::ConservedState MHD<fluid>::PrimitiveState::ToConserved(void) const
+{
+   MHD<fluid>::ConservedState cons;
+
+   cons.den() = den();
+   cons.mom() = vel() * den();
+   cons.enr() = Energy(den(), vel().Norm2(), mag().Norm2(), pre(), fluid);
+   cons.mag() = mag();
+
+#ifdef CL_MHD_GLM
+   cons.glm() = glm();
+#endif
+
+   return cons;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Flux vector
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC MHD<fluid>::FluxFunction MHD<fluid>::PrimitiveState::ToFlux(void) const
+{
+   double enr = Energy(den(), vel().Norm2(), mag().Norm2(), pre(), fluid);
+   double pre_tot = pre() + mag().Norm2() / M_8PI;
+   MHD<fluid>::FluxFunction flux;
+
+   flux.denf() = den() * vel()[0];
+   flux.momf() = den() * vel()[0] * vel() + pre_tot * gv_nx - (mag()[0] / M_4PI) * mag();
+   flux.enrf() = (enr + pre_tot) * vel()[0] - (vel() * mag()) * mag()[0] / M_4PI;
+   flux.magf() = vel()[0] * mag() - mag()[0] * vel();
+
+#ifdef CL_MHD_GLM
+// The GLM flux is proportional to the square of the fastest speed. The safety factor "CL_MHD_GLMSAFETY" is used to make sure it is slightly outside of the "normal" Riemann fan.
+   flux.magf() += glm() * gv_nx;
+
+// FIXME should this flux be calculated in the RS?
+//   flux.glmf() = Sqr(CL_MHD_GLMSAFETY * FastestWaveNormal()) * mag()[0];
+#endif
+
+   return flux;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Vector of primitive variables in a sonic state
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC MHD<fluid>::PrimitiveState MHD<fluid>::PrimitiveState::ToSonic(void) const
+{
+   GeoVector aa = mag() / sqrt(M_4PI * den());
+   double ax2 = Sqr(aa[0]);
+   double at2 = Sqr(aa[1]) + Sqr(aa[2]);
+   double c2 = Sound2(den(), pre(), fluid);
+   double c = sqrt(c2);
+   double s2 = c2 + ax2 + at2;
+   double d2 = sqrt(s2 - 4.0 * c2 * ax2);
+   double af2 = 0.5 * (s2 + d2);
+   double af = sqrt(af2);
+   double as2 = af2 - d2;
+   double den_prime = den() * fmax(1.0 - as2 / c2, sp_small);
+
+   double q2 = 0.25 * den() / af2 * ((gamma_eos[fluid] * c2 - s2) / den() + 2.0 * at2 * (d2 + s2) / d2 / den_prime
+      + (gamma_eos[fluid] * c2 * (s2 - 2.0 * ax2) - s2 * s2) / d2 / den());
+   double del_den = den() / (1.0 + q2) * (vel()[0] / af - 1.0);
+   double af_star = vel()[0] - af * del_den / den();
+   double cs_star = vel()[0] - c  * del_den / den();
+
+   MHD<fluid>::PrimitiveState prim;
+   
+   prim.den() = den() + del_den;
+   prim.vel()[0] = af_star;
+   prim.vel()[1] = vel()[1] + sqrt(as2) * aa[1] * sign(mag()[0]) * del_den / c / den_prime;
+   prim.vel()[2] = vel()[2] + sqrt(as2) * aa[2] * sign(mag()[0]) * del_den / c / den_prime;
+   prim.mag()[0] = mag()[0];
+   prim.mag()[1] = mag()[1] * (1.0 + del_den / den_prime);
+   prim.mag()[2] = mag()[2] * (1.0 + del_den / den_prime);
+   prim.pre() = prim.den() * Sqr(cs_star) / gamma_eos[fluid];
+
+   return prim;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void MHD<fluid>::PrimitiveState::Invert(void)
+{
+   vel()[0] = -vel()[0];
+   mag()[0] = -mag()[0];
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// MHD<fluid>::ConservedState methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] den_in Density
+\param[in] mom_in Momentum
+\param[in] enr_in Energy
+\param[in] mag_in Magnetic field
+\param[in] glm_in Largange multiplier
+*/
+template <int fluid>
+#ifdef CL_MHD_GLM
+SPECTRUM_DEVICE_FUNC MHD<fluid>::ConservedState::ConservedState(double den_in, const GeoVector& mom_in, double enr_in, const GeoVector& mag_in, double glm_in)
+#else
+SPECTRUM_DEVICE_FUNC MHD<fluid>::ConservedState::ConservedState(double den_in, const GeoVector& mom_in, double enr_in, const GeoVector& mag_in)
+#endif
+{
+   den() = den_in;
+   mom() = mom_in;
+   enr() = enr_in;
+   mag() = mag_in;
+
+#ifdef CL_MHD_GLM
+   glm() = glm_in;
+#endif
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] other Object to initialize from
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC MHD<fluid>::ConservedState::ConservedState(const SimpleArray<double, CL_MHD_NVARS>& other)
+                                               : SimpleArray<double, CL_MHD_NVARS>(other)
+{
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Fastest wave speed (max fast with GLM safety)
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double MHD<fluid>::ConservedState::FastestWave(void) const
+{
+   GeoVector vel = mom() / den();
+   double pre = Pressure(den(), vel.Norm2(), mag().Norm2(), enr(), fluid);
+   double Va2 = Alfven2(den(), mag().Norm2());
+   double Cs2 = Sound2(den(), pre, fluid);
+
+// FIXME decide where to use "CL_MHD_GLMSAFETY"
+//#ifdef CL_MHD_GLM
+   return sqrt(Va2 + Cs2);
+//#else
+//   return CL_MHD_GLMSAFETY * sqrt(Va2 + Cs2);
+//#endif
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Fastest normal wave speed (fast_n)
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double MHD<fluid>::ConservedState::FastestWaveNormal(void) const
+{
+   GeoVector vel = mom() / den();
+   double pre = Pressure(den(), vel.Norm2(), mag().Norm2(), enr(), fluid);
+   double Va2 = Alfven2(den(), mag().Norm2());
+   double Vax2 = Alfven2(den(), Sqr(mag()[0]));
+   double Cs2 = Sound2(den(), pre, fluid);
+
+   return FastMagnetosonicSpeed(Va2, Vax2, Cs2);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Vector of primitive variables
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC MHD<fluid>::PrimitiveState MHD<fluid>::ConservedState::ToPrimitive(void) const
+{
+   MHD<fluid>::PrimitiveState prim;
+
+   prim.den() = den();
+   prim.vel() = mom() / den();
+   prim.pre() = Pressure(den(), prim.vel().Norm2(), mag().Norm2(), enr(), fluid);
+   prim.mag() = mag();
+
+#ifdef CL_MHD_LAGR
+   prim.glm() = glm();
+#endif
+
+   return prim;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Flux vector
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC MHD<fluid>::FluxFunction MHD<fluid>::ConservedState::ToFlux(void) const
+{
+   GeoVector vel = mom() / den();
+   double pre = Pressure(den(), vel.Norm2(), mag().Norm2(), enr(), fluid);
+   double pre_tot = pre + mag().Norm2() / M_8PI;
+   MHD<fluid>::FluxFunction flux;
+
+   flux.denf() = mom()[0];
+   flux.momf() = mom()[0] * vel + pre_tot * gv_nx - (mag()[0] / M_4PI) * mag();
+   flux.enrf() = (enr() + pre_tot) * vel[0] - (vel * mag()) * mag()[0] / M_4PI;
+   flux.magf() = vel[0] * mag() - mag()[0] * vel;
+
+#ifdef CL_MHD_GLM
+// The GLM flux is proportional to the square of the fastest speed. The safety factor "CL_MHD_GLMSAFETY" is used to make sure it is slightly outside of the "normal" Riemann fan.
+   flux.magf() += glm() * gv_nx;
+
+// FIXME should this flux be calculated in the RS?
+//   flux.glmf() = Sqr(CL_MHD_GLMSAFETY * FastestWaveNormal()) * mag()[0];
+#endif
+
+   return flux;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Gas pressure
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC double MHD<fluid>::ConservedState::GetPressure(void) const
+{
+   return Pressure(den(), mom().Norm2() / Sqr(den()), mag().Norm2(), enr(), fluid);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] flux Flux vector
+\param[in] S1   First wave speed
+\param[in] S2   Second wave speed
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void MHD<fluid>::ConservedState::FixMomentum(MHD<fluid>::FluxFunction& flux, double S1, double S2)
+{
+   mom()[1] = (flux.mom()[1] - mag()[0] * mag()[1] / M_4PI) / (S1 - S2);
+   mom()[2] = (flux.mom()[2] - mag()[0] * mag()[2] / M_4PI) / (S1 - S2);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] flux Flux vector
+\param[in] S1   First wave speed
+\param[in] S2   Second wave speed
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void MHD<fluid>::ConservedState::FixEnergy(MHD<fluid>::FluxFunction& flux, double S1, double S2)
+{
+   double pre_total = S1 * mom()[0] + mag()[0] * mag()[0] / M_4PI - flux.mom()[0];
+   enr() = (flux.enr() - (mag()[0] * S2 + (mag()[1] * mom()[1] + mag()[2] * mom()[2]) / den()) * mag()[0] + pre_total * S2) / (S1 - S2);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void MHD<fluid>::ConservedState::Invert(void)
+{
+   mom()[0] = -mom()[0];
+   mag()[0] = -mag()[0];
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// FluxFunctionMHD methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] denf_in Density flux
+\param[in] momf_in Momentum flux
+\param[in] enrf_in Energy flux
+\param[in] magf_in Magnetic field
+\param[in] glmf_in Largange multiplier flux
+*/
+template <int fluid>
+#ifdef CL_MHD_GLM
+SPECTRUM_DEVICE_FUNC MHD<fluid>::FluxFunction::FluxFunction(double denf_in, const GeoVector& momf_in, double enrf_in, const GeoVector& magf_in, double glmf_in)
+#else
+SPECTRUM_DEVICE_FUNC MHD<fluid>::FluxFunction::FluxFunction(double denf_in, const GeoVector& momf_in, double enrf_in, const GeoVector& magf_in)
+#endif
+{
+   denf() = denf_in;
+   momf() = momf_in;
+   enrf() = enrf_in;
+   magf() = magf_in;
+
+#ifdef CL_MHD_GLM
+   glmf() = glmf_in;
+#endif
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] other Object to initialize from
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC MHD<fluid>::FluxFunction::FluxFunction(const SimpleArray<double, CL_MHD_NVARS>& other)
+                                             : SimpleArray<double, CL_MHD_NVARS>(other)
+{
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+*/
+template <int fluid>
+SPECTRUM_DEVICE_FUNC void MHD<fluid>::FluxFunction::Invert(void)
+{
+   momf()[0] = -momf()[0];
+   magf()[0] = -magf()[0];
+};
+
+};

--- a/fluid/conservation_laws_mhd.hh
+++ b/fluid/conservation_laws_mhd.hh
@@ -9,677 +9,261 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 #ifndef SPECTRUM_CONSERVATION_LAWS_MHD_HH
 #define SPECTRUM_CONSERVATION_LAWS_MHD_HH
 
-#include "common/physics.hh"
+#include "common/vectors.hh"
 
 namespace Spectrum {
 
-//! Number of fluid variables (DEN,VELx3,PRE,MAGx3)
-#define CL_MHD_NVARS 8
-
 //! Number of GLM variables
-#define CL_MHD_GLM 1
-#if (CL_MHD_GLM != 0) && (CL_MHD_GLM != 1)
-#error The number of GLM variables must be 0 or 1
-#endif
+#define CL_MHD_GLM
 
+#ifdef CL_MHD_GLM
+//! Number of fluid variables (DEN,VELx3,PRE,MAGx3, GLM)
+#define CL_MHD_NVARS 9
 //! Safety factor for GLM transport
 #define CL_MHD_GLMSAFETY 1.05
 
-//! Total number of variables
-#define CL_MHD_TOTAL (CL_MHD_NVARS + CL_MHD_GLM + n_ind)
-
-template <int fluid, int n_ind> struct PrimitiveStateMHD;
-template <int fluid, int n_ind> struct ConservedStateMHD;
-template <int fluid, int n_ind> struct FluxFunctionMHD;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// PrimitiveStateMHD class declaration
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-template <int fluid, int n_ind>
-struct PrimitiveStateMHD : public SimpleArray<double, CL_MHD_TOTAL>
-{
-   using SimpleArray<double, CL_MHD_TOTAL>::data;
-
-//! Alias for density (RO)
-   const double& den(void) const {return data[0];};
-
-//! Alias for density (RW)
-   double& den(void) {return data[0];};
-
-//! Alias for velocity (RO)
-   const GeoVector& vel(void) const {return (const GeoVector&)data[1];};
-
-//! Alias for velocity (RW)
-   GeoVector& vel(void) {return (GeoVector&)data[1];};
-
-//! Alias for pressure (RO)
-   const double& pre(void) const {return data[4];};
-
-//! Alias for pressure (RW)
-   double& pre(void) {return data[4];};
-
-//! Alias for magnetic field (RO)
-   const GeoVector& mag(void) const {return (const GeoVector&)data[5];};
-
-//! Alias for magnetic field (RW)
-   GeoVector& mag(void) {return (GeoVector&)data[5];};
-
-#if CL_MHD_GLM != 0
-
-//! Alias for Largange multiplier (RO)
-   const double& glm(void) const {return data[8];};
-
-//! Alias for Largange multiplier (RW)
-   double& glm(void) {return data[8];};
-
+#else
+//! Number of fluid variables (DEN,VELx3,PRE,MAGx3)
+#define CL_MHD_NVARS 8
 #endif
+
+/*!
+\brief Codifies physics of MHD
+\author Vladimir Florinski
+*/
+template <int fluid>
+class MHD
+{
+public:
+
+   struct ConservedState;
+   struct FluxFunction;
+
+//! A trait to be used in template specializations
+   static constexpr bool is_cons_law_active = true;
 
 //! Return the "fluid" template parameter
-   SPECTRUM_DEVICE_FUNC int Fluid(void) const {return fluid;};
+   SPECTRUM_DEVICE_FUNC static constexpr int Fluid(void) {return fluid;};
 
-//! Return the "n_ind" template parameter
-   SPECTRUM_DEVICE_FUNC int Nind(void) const {return n_ind;};
+//! Return the number of variables
+   SPECTRUM_DEVICE_FUNC static constexpr int Nvars(void) {return CL_MHD_NVARS;};
 
-//! Return the number of main variables
-   SPECTRUM_DEVICE_FUNC int Nmain(void) const {return CL_MHD_NVARS;};
+/*!
+\brief Codifies physics of MHD for primitive variables
+\author Vladimir Florinski
+*/
+   struct PrimitiveState : public SimpleArray<double, CL_MHD_NVARS>
+   {
+      using SimpleArray<double, CL_MHD_NVARS>::data;
 
-//! Default constructor
-   SPECTRUM_DEVICE_FUNC PrimitiveStateMHD(void) = default;
+   //! Alias for density (RO)
+      const double& den(void) const {return data[0];};
 
-#if CL_MHD_GLM == 0
-//! Constructor from components
-   SPECTRUM_DEVICE_FUNC PrimitiveStateMHD(double den_in, const GeoVector& vel_in, double pre_in, const GeoVector& mag_in, double* ind_in);
+   //! Alias for density (RW)
+      double& den(void) {return data[0];};
+
+   //! Alias for velocity (RO)
+      const GeoVector& vel(void) const {return (const GeoVector&)data[1];};
+
+   //! Alias for velocity (RW)
+      GeoVector& vel(void) {return (GeoVector&)data[1];};
+
+   //! Alias for pressure (RO)
+      const double& pre(void) const {return data[4];};
+
+   //! Alias for pressure (RW)
+      double& pre(void) {return data[4];};
+
+   //! Alias for magnetic field (RO)
+      const GeoVector& mag(void) const {return (const GeoVector&)data[5];};
+
+   //! Alias for magnetic field (RW)
+      GeoVector& mag(void) {return (GeoVector&)data[5];};
+
+#ifdef CL_MHD_GLM
+
+   //! Alias for Largange multiplier (RO)
+      const double& glm(void) const {return data[8];};
+
+   //! Alias for Largange multiplier (RW)
+      double& glm(void) {return data[8];};
+
+#endif
+
+   //! Default constructor
+      SPECTRUM_DEVICE_FUNC PrimitiveState(void) = default;
+
+#ifdef CL_MHD_GLM
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC PrimitiveState(double den_in, const GeoVector& vel_in, double pre_in, const GeoVector& mag_in, double glm_in);
 #else
-//! Constructor from components
-   SPECTRUM_DEVICE_FUNC PrimitiveStateMHD(double den_in, const GeoVector& vel_in, double pre_in, const GeoVector& mag_in, double glm_in, double* ind_in);
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC PrimitiveState(double den_in, const GeoVector& vel_in, double pre_in, const GeoVector& mag_in);
 #endif
 
-//! Constructor from the base class
-   SPECTRUM_DEVICE_FUNC PrimitiveStateMHD(const SimpleArray<double, CL_MHD_TOTAL>& other);
+   //! Constructor from SimpleArray
+      SPECTRUM_DEVICE_FUNC PrimitiveState(const SimpleArray<double, CL_MHD_NVARS>& other);
 
-//! Calculate the fastest wave speed
-   SPECTRUM_DEVICE_FUNC double FastestWave(void) const;
+   //! Calculate the fastest wave speed
+      SPECTRUM_DEVICE_FUNC double FastestWave(void) const;
 
-//! Calculate the fastest normal wave speed
-   SPECTRUM_DEVICE_FUNC double FastestWaveNormal(void) const;
+   //! Calculate the fastest normal wave speed
+      SPECTRUM_DEVICE_FUNC double FastestWaveNormal(void) const;
 
-//! Calculate primitive state
-   SPECTRUM_DEVICE_FUNC ConservedStateMHD<fluid, n_ind> ToConserved(bool ind_ok) const;
+   //! Calculate primitive state
+      SPECTRUM_DEVICE_FUNC ConservedState ToConserved(void) const;
 
-//! Calculate flux function
-   SPECTRUM_DEVICE_FUNC FluxFunctionMHD<fluid, n_ind> ToFlux(bool ind_ok) const;
+   //! Calculate flux function
+      SPECTRUM_DEVICE_FUNC FluxFunction ToFlux(void) const;
 
-//! Invert vector variables
-   SPECTRUM_DEVICE_FUNC void Invert(void);
-};
+   //! Calculate sonic state
+      SPECTRUM_DEVICE_FUNC PrimitiveState ToSonic(void) const;
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// ConservedStateMHD class declaration
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-template <int fluid, int n_ind>
-struct ConservedStateMHD : public SimpleArray<double, CL_MHD_TOTAL>
-{
-   using SimpleArray<double, CL_MHD_TOTAL>::data;
-
-//! Alias for density (RO)
-   const double& den(void) const {return data[0];};
-
-//! Alias for density (RW)
-   double& den(void) {return data[0];};
-
-//! Alias for momentum (RO)
-   const GeoVector& mom(void) const {return (const GeoVector&)data[1];};
-
-//! Alias for momentum (RW)
-   GeoVector& mom(void) {return (GeoVector&)data[1];};
-
-//! Alias for energy (RO)
-   const double& enr(void) const {return data[4];};
-
-//! Alias for energy (RW)
-   double& enr(void) {return data[4];};
-
-//! Alias for magnetic field (RO)
-   const GeoVector& mag(void) const {return (const GeoVector&)data[5];};
-
-//! Alias for magnetic field (RW)
-   GeoVector& mag(void) {return (GeoVector&)data[5];};
-
-#if CL_MHD_GLM != 0
-
-//! Alias for Largange multiplier (RO)
-   const double& glm(void) const {return data[8];};
-
-//! Alias for Largange multiplier (RW)
-   double& glm(void) {return data[8];};
-
-#endif
-
-//! Return the "fluid" template parameter
-   SPECTRUM_DEVICE_FUNC int Fluid(void) const {return fluid;};
-
-//! Return the "n_ind" template parameter
-   SPECTRUM_DEVICE_FUNC int Nind(void) const {return n_ind;};
-
-//! Return the number of main variables
-   SPECTRUM_DEVICE_FUNC int Nmain(void) const {return CL_MHD_NVARS;};
-
-//! Default constructor
-   SPECTRUM_DEVICE_FUNC ConservedStateMHD(void) = default;
-
-#if CL_MHD_GLM == 0
-//! Constructor from components
-   SPECTRUM_DEVICE_FUNC ConservedStateMHD(double den_in, const GeoVector& mom_in, double enr_in, const GeoVector& mag_in, double* ind_in);
-#else
-//! Constructor from components
-   SPECTRUM_DEVICE_FUNC ConservedStateMHD(double den_in, const GeoVector& mom_in, double enr_in, const GeoVector& mag_in, double glm_in, double* ind_in);
-#endif
-
-//! Constructor from the base class
-   SPECTRUM_DEVICE_FUNC ConservedStateMHD(const SimpleArray<double, CL_MHD_TOTAL>& other);
-
-//! Calculate the fastest wave speed
-   SPECTRUM_DEVICE_FUNC double FastestWave(void) const;
-
-//! Calculate the fastest normal wave speed
-   SPECTRUM_DEVICE_FUNC double FastestWaveNormal(void) const;
-
-//! Calculate primitive state
-   SPECTRUM_DEVICE_FUNC PrimitiveStateMHD<fluid, n_ind> ToPrimitive(bool ind_ok) const;
-
-//! Calculate flux function
-   SPECTRUM_DEVICE_FUNC FluxFunctionMHD<fluid, n_ind> ToFlux(bool ind_ok) const;
-
-//! Calculate _gas_ pressure
-   SPECTRUM_DEVICE_FUNC double GetPressure(void) const;
-
-//! Calculate y and z components of momentum from the externally provided flux in a moving frame
-   SPECTRUM_DEVICE_FUNC void FixMomentum(FluxFunctionMHD<fluid, n_ind>& flux, double S1, double S2);
-
-//! Calculate energy from the externally provided flux in a moving frame
-   SPECTRUM_DEVICE_FUNC void FixEnergy(FluxFunctionMHD<fluid, n_ind>& flux, double S1, double S2);
-
-//! Invert vector variables
-   SPECTRUM_DEVICE_FUNC void Invert(void);
-};
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// FluxFunctionMHD class declaration
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-template <int fluid, int n_ind>
-struct FluxFunctionMHD : public SimpleArray<double, CL_MHD_TOTAL>
-{
-   using SimpleArray<double, CL_MHD_TOTAL>::data;
-
-//! Alias for density flux (RO)
-   const double& denf(void) const {return data[0];};
-
-//! Alias for density flux (RW)
-   double& denf(void) {return data[0];};
-
-//! Alias for momentum flux (RO)
-   const GeoVector& momf(void) const {return (const GeoVector&)data[1];};
-
-//! Alias for momentum flux (RW)
-   GeoVector& momf(void) {return (GeoVector&)data[1];};
-
-//! Alias for energy flux (RO)
-   const double& enrf(void) const {return data[4];};
-
-//! Alias for energy flux (RW)
-   double& enrf(void) {return data[4];};
-
-//! Alias for magnetic flux (RO)
-   const GeoVector& magf(void) const {return (const GeoVector&)data[5];};
-
-//! Alias for magnetic flux (RW)
-   GeoVector& magf(void) {return (GeoVector&)data[5];};
-
-#if CL_MHD_GLM != 0
-
-//! Alias for Largange multiplier flux (RO)
-   const double& glmf(void) const {return data[8];};
-
-//! Alias for Largange multiplier flux (RO)
-   double& glmf(void) {return data[8];};
-
-#endif
-
-//! Return the "fluid" template parameter
-   SPECTRUM_DEVICE_FUNC int Fluid(void) const {return fluid;};
-
-//! Return the "n_ind" template parameter
-   SPECTRUM_DEVICE_FUNC int Nind(void) const {return n_ind;};
-
-//! Return the number of main variables
-   SPECTRUM_DEVICE_FUNC int Nmain(void) const {return CL_MHD_NVARS;};
-
-//! Default constructor
-   SPECTRUM_DEVICE_FUNC FluxFunctionMHD(void) = default;
-
-#if CL_MHD_GLM == 0
-//! Constructor from components
-   SPECTRUM_DEVICE_FUNC FluxFunctionMHD(double denf_in, const GeoVector& momf_in, double enrf_in, const GeoVector& magf_in, double* indf_in);
-#else
-//! Constructor from components
-   SPECTRUM_DEVICE_FUNC FluxFunctionMHD(double denf_in, const GeoVector& momf_in, double enrf_in, const GeoVector& magf_in, double glmf_in, double* indf_in);
-#endif
-
-//! Constructor from the base class
-   SPECTRUM_DEVICE_FUNC FluxFunctionMHD(const SimpleArray<double, CL_MHD_TOTAL>& other);
-
-//! Invert vector variables
-   SPECTRUM_DEVICE_FUNC void Invert(void);
-};
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// PrimitiveStateMHD inline methods
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-/*!
-\author Vladimir Florinski
-\date 03/14/2024
-\param[in] den_in Density
-\param[in] vel_in Velocity
-\param[in] pre_in Pressure
-\param[in] mag_in Magnetic field
-\param[in] glm_in Largange multiplier
-\param[in] ind_in Indicator variables
-*/
-template <int fluid, int n_ind>
-#if CL_MHD_GLM == 0
-SPECTRUM_DEVICE_FUNC inline PrimitiveStateMHD<fluid, n_ind>::PrimitiveStateMHD(double den_in, const GeoVector& vel_in, double pre_in,
-                                                                               const GeoVector& mag_in, double* ind_in)
-#else
-SPECTRUM_DEVICE_FUNC inline PrimitiveStateMHD<fluid, n_ind>::PrimitiveStateMHD(double den_in, const GeoVector& vel_in, double pre_in,
-                                                                               const GeoVector& mag_in, double glm_in, double* ind_in)
-#endif
-{
-   den() = den_in;
-   vel() = vel_in;
-   pre() = pre_in;
-   mag() = mag_in;
-
-#if CL_MHD_GLM != 0
-   glm() = glm_in;
-#endif
-
-   if(n_ind != 0) memcpy(data + CL_MHD_NVARS + CL_MHD_GLM, ind_in, n_ind * sizeof(double));
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/14/2024
-\param[in] other Object to initialize from
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline PrimitiveStateMHD<fluid, n_ind>::PrimitiveStateMHD(const SimpleArray<double, CL_MHD_TOTAL>& other)
-   : SimpleArray<double, CL_MHD_TOTAL>(other)
-{
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/16/2024
-\return Fastest wave speed (max fast with GLM safety)
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double PrimitiveStateMHD<fluid, n_ind>::FastestWave(void) const
-{
-   double Va2 = Alfven2(den(), mag().Norm2());
-   double Cs2 = Sound2(den(), pre(), fluid);
-
-// FIXME decide where to use "CL_MHD_GLMSAFETY"
-//#if CL_MHD_GLM == 0
-   return sqrt(Va2 + Cs2);
-//#else
-//   return CL_MHD_GLMSAFETY * sqrt(Va2 + Cs2);
-//#endif
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/16/2024
-\return Fastest normal wave speed (fast_n)
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double PrimitiveStateMHD<fluid, n_ind>::FastestWaveNormal(void) const
-{
-   double Va2 = Alfven2(den(), mag().Norm2());
-   double Vax2 = Alfven2(den(), Sqr(mag()[0]));
-   double Cs2 = Sound2(den(), pre(), fluid);
-
-   return FastMagnetosonicSpeed(Va2, Vax2, Cs2);
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/06/2024
-\return Vector of conserved variables
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline ConservedStateMHD<fluid, n_ind> PrimitiveStateMHD<fluid, n_ind>::ToConserved(bool ind_ok) const
-{
-   ConservedStateMHD<fluid, n_ind> cons;
-
-   cons.den() = den();
-   cons.mom() = vel() * den();
-   cons.enr() = Energy(den(), vel().Norm2(), mag().Norm2(), pre(), fluid);
-   cons.mag() = mag();
-
-#if CL_MHD_GLM != 0
-   cons.glm() = glm();
-#endif
-
-// Optionally convert the indicator variables
-   if(ind_ok) {
-      for(auto i = CL_MHD_NVARS + CL_MHD_GLM; i < CL_MHD_NVARS + CL_MHD_GLM + n_ind; i++) {
-         cons.data[i] = den() * data[i];
-      };
+   //! Invert vector variables
+      SPECTRUM_DEVICE_FUNC void Invert(void);
    };
-   return cons;
-};
 
 /*!
+\brief Codifies physics of MHD for conserved variables
 \author Vladimir Florinski
-\date 03/06/2024
-\return Flux vector
 */
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline FluxFunctionMHD<fluid, n_ind> PrimitiveStateMHD<fluid, n_ind>::ToFlux(bool ind_ok) const
-{
-   double enr = Energy(den(), vel().Norm2(), mag().Norm2(), pre(), fluid);
-   double pre_tot = pre() + mag().Norm2() / eightpi;
-   FluxFunctionMHD<fluid, n_ind> flux;
+   struct ConservedState : public SimpleArray<double, CL_MHD_NVARS>
+   {
+      using SimpleArray<double, CL_MHD_NVARS>::data;
 
-   flux.denf() = den() * vel()[0];
-   flux.momf() = den() * vel()[0] * vel() + pre_tot * gv_nx - (mag()[0] / fourpi) * mag();
-   flux.enrf() = (enr + pre_tot) * vel()[0] - (vel() * mag()) * mag()[0] / fourpi;
-   flux.magf() = vel()[0] * mag() - mag()[0] * vel();
+   //! Alias for density (RO)
+      const double& den(void) const {return data[0];};
 
-#if CL_MHD_GLM != 0
-// The GLM flux is proportional to the square of the fastest speed. The safety factor "CL_MHD_GLMSAFETY" is used to make sure it is slightly outside of the "normal" Riemann fan.
-   flux.magf() += glm() * gv_nx;
+   //! Alias for density (RW)
+      double& den(void) {return data[0];};
 
-// FIXME should this flux be calculated in the RS?
-//   flux.glmf() = Sqr(CL_MHD_GLMSAFETY * FastestWaveNormal()) * mag()[0];
+   //! Alias for momentum (RO)
+      const GeoVector& mom(void) const {return (const GeoVector&)data[1];};
+
+   //! Alias for momentum (RW)
+      GeoVector& mom(void) {return (GeoVector&)data[1];};
+
+   //! Alias for energy (RO)
+      const double& enr(void) const {return data[4];};
+
+   //! Alias for energy (RW)
+      double& enr(void) {return data[4];};
+
+   //! Alias for magnetic field (RO)
+      const GeoVector& mag(void) const {return (const GeoVector&)data[5];};
+
+   //! Alias for magnetic field (RW)
+      GeoVector& mag(void) {return (GeoVector&)data[5];};
+
+#ifdef CL_MHD_GLM
+
+   //! Alias for Largange multiplier (RO)
+      const double& glm(void) const {return data[8];};
+
+   //! Alias for Largange multiplier (RW)
+      double& glm(void) {return data[8];};
+
 #endif
 
-// Optionally convert the indicator variables
-   if(ind_ok) {
-      for(auto i = CL_MHD_NVARS + CL_MHD_GLM; i < CL_MHD_NVARS + CL_MHD_GLM + n_ind; i++) {
-         flux.data[i] = den() * data[i] * vel()[0];
-      };
-   };
-   return flux;
-};
+   //! Default constructor
+      SPECTRUM_DEVICE_FUNC ConservedState(void) = default;
 
-/*!
-\author Vladimir Florinski
-\date 04/09/2024
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void PrimitiveStateMHD<fluid, n_ind>::Invert(void)
-{
-   vel()[0] = -vel()[0];
-   mag()[0] = -mag()[0];
-};
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// ConservedStateMHD inline methods
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-/*!
-\author Vladimir Florinski
-\date 03/14/2024
-\param[in] den_in Density
-\param[in] mom_in Momentum
-\param[in] enr_in Energy
-\param[in] mag_in Magnetic field
-\param[in] glm_in Largange multiplier
-\param[in] ind_in Indicator variables
-*/
-template <int fluid, int n_ind>
-#if CL_MHD_GLM == 0
-SPECTRUM_DEVICE_FUNC inline ConservedStateMHD<fluid, n_ind>::ConservedStateMHD(double den_in, const GeoVector& mom_in, double enr_in,
-                                                                               const GeoVector& mag_in, double* ind_in)
+#ifdef CL_MHD_GLM
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC ConservedState(double den_in, const GeoVector& mom_in, double enr_in, const GeoVector& mag_in, double glm_in);
 #else
-SPECTRUM_DEVICE_FUNC inline ConservedStateMHD<fluid, n_ind>::ConservedStateMHD(double den_in, const GeoVector& mom_in, double enr_in,
-                                                                               const GeoVector& mag_in, double glm_in, double* ind_in)
-#endif
-{
-   den() = den_in;
-   mom() = mom_in;
-   enr() = enr_in;
-   mag() = mag_in;
-
-#if CL_MHD_GLM != 0
-   glm() = glm_in;
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC ConservedState(double den_in, const GeoVector& mom_in, double enr_in, const GeoVector& mag_in);
 #endif
 
-   if(n_ind != 0) memcpy(data + CL_MHD_NVARS + CL_MHD_GLM, ind_in, n_ind * sizeof(double));
-};
+   //! Constructor from SimpleArray
+      SPECTRUM_DEVICE_FUNC ConservedState(const SimpleArray<double, CL_MHD_NVARS>& other);
 
-/*!
-\author Vladimir Florinski
-\date 03/14/2024
-\param[in] other Object to initialize from
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline ConservedStateMHD<fluid, n_ind>::ConservedStateMHD(const SimpleArray<double, CL_MHD_TOTAL>& other)
-   : SimpleArray<double, CL_MHD_TOTAL>(other)
-{
-};
+   //! Calculate the fastest wave speed
+      SPECTRUM_DEVICE_FUNC double FastestWave(void) const;
 
-/*!
-\author Vladimir Florinski
-\date 03/16/2024
-\return Fastest wave speed (max fast with GLM safety)
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double ConservedStateMHD<fluid, n_ind>::FastestWave(void) const
-{
-   GeoVector vel = mom() / den();
-   double pre = Pressure(den(), vel.Norm2(), mag().Norm2(), enr(), fluid);
-   double Va2 = Alfven2(den(), mag().Norm2());
-   double Cs2 = Sound2(den(), pre, fluid);
+   //! Calculate the fastest normal wave speed
+      SPECTRUM_DEVICE_FUNC double FastestWaveNormal(void) const;
 
-// FIXME decide where to use "CL_MHD_GLMSAFETY"
-//#if CL_MHD_GLM == 0
-   return sqrt(Va2 + Cs2);
-//#else
-//   return CL_MHD_GLMSAFETY * sqrt(Va2 + Cs2);
-//#endif
-};
+   //! Calculate primitive state
+      SPECTRUM_DEVICE_FUNC PrimitiveState ToPrimitive(void) const;
 
-/*!
-\author Vladimir Florinski
-\date 03/16/2024
-\return Fastest normal wave speed (fast_n)
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double ConservedStateMHD<fluid, n_ind>::FastestWaveNormal(void) const
-{
-   GeoVector vel = mom() / den();
-   double pre = Pressure(den(), vel.Norm2(), mag().Norm2(), enr(), fluid);
-   double Va2 = Alfven2(den(), mag().Norm2());
-   double Vax2 = Alfven2(den(), Sqr(mag()[0]));
-   double Cs2 = Sound2(den(), pre, fluid);
+   //! Calculate flux function
+      SPECTRUM_DEVICE_FUNC FluxFunction ToFlux(void) const;
 
-   return FastMagnetosonicSpeed(Va2, Vax2, Cs2);
-};
+   //! Calculate _gas_ pressure
+      SPECTRUM_DEVICE_FUNC double GetPressure(void) const;
 
-/*!
-\author Vladimir Florinski
-\date 03/06/2024
-\return Vector of primitive variables
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline PrimitiveStateMHD<fluid, n_ind> ConservedStateMHD<fluid, n_ind>::ToPrimitive(bool ind_ok) const
-{
-   PrimitiveStateMHD<fluid, n_ind> prim;
+   //! Calculate y and z components of momentum from the externally provided flux in a moving frame
+      SPECTRUM_DEVICE_FUNC void FixMomentum(FluxFunction& flux, double S1, double S2);
 
-   prim.den() = den();
-   prim.vel() = mom() / den();
-   prim.pre() = Pressure(den(), prim.vel().Norm2(), mag().Norm2(), enr(), fluid);
-   prim.mag() = mag();
+   //! Calculate energy from the externally provided flux in a moving frame
+      SPECTRUM_DEVICE_FUNC void FixEnergy(FluxFunction& flux, double S1, double S2);
 
-#if CL_MHD_LAGR != 0
-   prim.glm() = glm();
-#endif
-
-// Optionally convert the indicator variables
-   if(ind_ok) {
-      for(auto i = CL_MHD_NVARS + CL_MHD_GLM; i < CL_MHD_NVARS + CL_MHD_GLM + n_ind; i++) {
-         prim.data[i] = data[i] / den();
-      };
+   //! Invert vector variables
+      SPECTRUM_DEVICE_FUNC void Invert(void);
    };
-   return prim;
-};
 
 /*!
+\brief Codifies physics of MHD for the fluxes
 \author Vladimir Florinski
-\date 03/14/2024
-\return Flux vector
 */
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline FluxFunctionMHD<fluid, n_ind> ConservedStateMHD<fluid, n_ind>::ToFlux(bool ind_ok) const
-{
-   GeoVector vel = mom() / den();
-   double pre = Pressure(den(), vel.Norm2(), mag().Norm2(), enr(), fluid);
-   double pre_tot = pre + mag().Norm2() / eightpi;
-   FluxFunctionMHD<fluid, n_ind> flux;
+   struct FluxFunction : public SimpleArray<double, CL_MHD_NVARS>
+   {
+      using SimpleArray<double, CL_MHD_NVARS>::data;
 
-   flux.denf() = mom()[0];
-   flux.momf() = mom()[0] * vel + pre_tot * gv_nx - (mag()[0] / fourpi) * mag();
-   flux.enrf() = (enr() + pre_tot) * vel[0] - (vel * mag()) * mag()[0] / fourpi;
-   flux.magf() = vel[0] * mag() - mag()[0] * vel;
+   //! Alias for density flux (RO)
+      const double& denf(void) const {return data[0];};
 
-#if CL_MHD_GLM != 0
-// The GLM flux is proportional to the square of the fastest speed. The safety factor "CL_MHD_GLMSAFETY" is used to make sure it is slightly outside of the "normal" Riemann fan.
-   flux.magf() += glm() * gv_nx;
+   //! Alias for density flux (RW)
+      double& denf(void) {return data[0];};
 
-// FIXME should this flux be calculated in the RS?
-//   flux.glmf() = Sqr(CL_MHD_GLMSAFETY * FastestWaveNormal()) * mag()[0];
+   //! Alias for momentum flux (RO)
+      const GeoVector& momf(void) const {return (const GeoVector&)data[1];};
+
+   //! Alias for momentum flux (RW)
+      GeoVector& momf(void) {return (GeoVector&)data[1];};
+
+   //! Alias for energy flux (RO)
+      const double& enrf(void) const {return data[4];};
+
+   //! Alias for energy flux (RW)
+      double& enrf(void) {return data[4];};
+
+   //! Alias for magnetic flux (RO)
+      const GeoVector& magf(void) const {return (const GeoVector&)data[5];};
+
+   //! Alias for magnetic flux (RW)
+      GeoVector& magf(void) {return (GeoVector&)data[5];};
+
+#ifdef CL_MHD_GLM
+
+   //! Alias for Largange multiplier flux (RO)
+      const double& glmf(void) const {return data[8];};
+
+   //! Alias for Largange multiplier flux (RO)
+      double& glmf(void) {return data[8];};
+
 #endif
 
-// Optionally convert the indicator variables
-   if(ind_ok) {
-      for(auto i = CL_MHD_NVARS; i < CL_MHD_NVARS + n_ind; i++) {
-         flux.data[i] = data[i] * mom()[0];
-      };
-   };
-   return flux;
-};
+   //! Default constructor
+      SPECTRUM_DEVICE_FUNC FluxFunction(void) = default;
 
-/*!
-\author Vladimir Florinski
-\date 03/20/2024
-\return Gas pressure
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline double ConservedStateMHD<fluid, n_ind>::GetPressure(void) const
-{
-   return Pressure(den(), mom().Norm2() / Sqr(den()), mag().Norm2(), enr(), fluid);
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/20/2024
-\param[in] flux Flux vector
-\param[in] S1   First wave speed
-\param[in] S2   Second wave speed
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void ConservedStateMHD<fluid, n_ind>::FixMomentum(FluxFunctionMHD<fluid, n_ind>& flux, double S1, double S2)
-{
-   mom()[1] = (flux.mom()[1] - mag()[0] * mag()[1] / fourpi) / (S1 - S2);
-   mom()[2] = (flux.mom()[2] - mag()[0] * mag()[2] / fourpi) / (S1 - S2);
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/20/2024
-\param[in] flux Flux vector
-\param[in] S1   First wave speed
-\param[in] S2   Second wave speed
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void ConservedStateMHD<fluid, n_ind>::FixEnergy(FluxFunctionMHD<fluid, n_ind>& flux, double S1, double S2)
-{
-   double pre_total = S1 * mom()[0] + mag()[0] * mag()[0] / fourpi - flux.mom()[0];
-   enr() = (flux.enr() - (mag()[0] * S2 + (mag()[1] * mom()[1] + mag()[2] * mom()[2]) / den()) * mag()[0] + pre_total * S2) / (S1 - S2);
-};
-
-/*!
-\author Vladimir Florinski
-\date 04/09/2024
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void ConservedStateMHD<fluid, n_ind>::Invert(void)
-{
-   mom()[0] = -mom()[0];
-   mag()[0] = -mag()[0];
-};
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// FluxFunctionMHD inline methods
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-/*!
-\author Vladimir Florinski
-\date 03/15/2024
-\param[in] denf_in Density flux
-\param[in] momf_in Momentum flux
-\param[in] enrf_in Energy flux
-\param[in] magf_in Magnetic field
-\param[in] glmf_in Largange multiplier flux
-\param[in] indf_in Indicator variables flux
-*/
-template <int fluid, int n_ind>
-#if CL_MHD_GLM == 0
-SPECTRUM_DEVICE_FUNC inline FluxFunctionMHD<fluid, n_ind>::FluxFunctionMHD(double denf_in, const GeoVector& momf_in, double enrf_in,
-                                                                           const GeoVector& magf_in, double* indf_in)
+#ifdef CL_MHD_GLM
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC FluxFunction(double denf_in, const GeoVector& momf_in, double enrf_in, const GeoVector& magf_in, double glmf_in);
 #else
-SPECTRUM_DEVICE_FUNC inline FluxFunctionMHD<fluid, n_ind>::FluxFunctionMHD(double denf_in, const GeoVector& momf_in, double enrf_in,
-                                                                           const GeoVector& magf_in, double glmf_in, double* indf_in)
-#endif
-{
-   denf() = denf_in;
-   momf() = momf_in;
-   enrf() = enrf_in;
-   magf() = magf_in;
-
-#if CL_MHD_GLM != 0
-   glmf() = glmf_in;
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC FluxFunction(double denf_in, const GeoVector& momf_in, double enrf_in, const GeoVector& magf_in);
 #endif
 
-   if(n_ind != 0) memcpy(data + CL_MHD_NVARS + CL_MHD_GLM, indf_in, n_ind * sizeof(double));
-};
+   //! Constructor from SimpleArray
+      SPECTRUM_DEVICE_FUNC FluxFunction(const SimpleArray<double, CL_MHD_NVARS>& other);
 
-/*!
-\author Vladimir Florinski
-\date 03/14/2024
-\param[in] other Object to initialize from
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline FluxFunctionMHD<fluid, n_ind>::FluxFunctionMHD(const SimpleArray<double, CL_MHD_TOTAL>& other)
-   : SimpleArray<double, CL_MHD_TOTAL>(other)
-{
-};
+   //! Invert vector variables
+      SPECTRUM_DEVICE_FUNC void Invert(void);
+   };
 
-/*!
-\author Vladimir Florinski
-\date 04/09/2024
-*/
-template <int fluid, int n_ind>
-SPECTRUM_DEVICE_FUNC inline void FluxFunctionMHD<fluid, n_ind>::Invert(void)
-{
-   momf()[0] = -momf()[0];
-   magf()[0] = -magf()[0];
 };
 
 };

--- a/fluid/conservation_laws_passive.cc
+++ b/fluid/conservation_laws_passive.cc
@@ -1,0 +1,129 @@
+/*!
+\file conservation_laws_passive.cc
+\brief Implements rules for a passively advected scalar (PAS)
+\author Vladimir Florinski
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
+*/
+
+#include "fluid/conservation_laws_passive.hh"
+
+namespace Spectrum {
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Passive::PrimitiveState methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] pas_in PAS
+*/
+SPECTRUM_DEVICE_FUNC Passive::PrimitiveState::PrimitiveState(double pas_in)
+{
+   pas() = pas_in;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] other Object to initialize from
+*/
+SPECTRUM_DEVICE_FUNC Passive::PrimitiveState::PrimitiveState(const SimpleArray<double, CL_PASSIVE_NVARS>& other)
+                                            : SimpleArray<double, CL_PASSIVE_NVARS>(other)
+{
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Vector of conserved variables
+*/
+template <typename ActiveConsLaw, std::enable_if_t<ActiveConsLaw::is_cons_law_active, bool>>
+SPECTRUM_DEVICE_FUNC Passive::ConservedState Passive::PrimitiveState::ToConserved(const ActiveConsLaw::PrimitiveState& active_prim) const
+{
+   return Passive::ConservedState(active_prim.den() * pas());
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Flux vector
+*/
+template <typename ActiveConsLaw, std::enable_if_t<ActiveConsLaw::is_cons_law_active, bool>>
+SPECTRUM_DEVICE_FUNC Passive::FluxFunction Passive::PrimitiveState::ToFlux(const ActiveConsLaw::PrimitiveState& active_prim) const
+{
+   return Passive::FluxFunction(active_prim.den() * pas() * active_prim.vel()[0]);
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Passive::ConservedState methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] dpas_in primary density*PAS
+*/
+SPECTRUM_DEVICE_FUNC Passive::ConservedState::ConservedState(double dpas_in)
+{
+   dpas() = dpas_in;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] other Object to initialize from
+*/
+SPECTRUM_DEVICE_FUNC Passive::ConservedState::ConservedState(const SimpleArray<double, CL_PASSIVE_NVARS>& other)
+                                            : SimpleArray<double, CL_PASSIVE_NVARS>(other)
+{
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Vector of primitive variables
+*/
+template <typename ActiveConsLaw, std::enable_if_t<ActiveConsLaw::is_cons_law_active, bool>>
+SPECTRUM_DEVICE_FUNC Passive::PrimitiveState Passive::ConservedState::ToPrimitive(const ActiveConsLaw::PrimitiveState& active_prim) const
+{
+   return Passive::PrimitiveState(dpas() / active_prim.den());
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Flux vector
+*/
+template <typename ActiveConsLaw, std::enable_if_t<ActiveConsLaw::is_cons_law_active, bool>>
+SPECTRUM_DEVICE_FUNC Passive::FluxFunction Passive::ConservedState::ToFlux(const ActiveConsLaw::PrimitiveState& active_prim) const
+{
+   return Passive::FluxFunction(dpas() * active_prim.vel()[0]);
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Passive::FluxFunction methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] dvarf_in Flux of primary density*PAS
+*/
+SPECTRUM_DEVICE_FUNC Passive::FluxFunction::FluxFunction(double dpasf_in)
+{
+   dpasf() = dpasf_in;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\param[in] other Object to initialize from
+*/
+SPECTRUM_DEVICE_FUNC Passive::FluxFunction::FluxFunction(const SimpleArray<double, CL_PASSIVE_NVARS>& other)
+                                          : SimpleArray<double, CL_PASSIVE_NVARS>(other)
+{
+};
+
+};

--- a/fluid/conservation_laws_passive.hh
+++ b/fluid/conservation_laws_passive.hh
@@ -1,0 +1,128 @@
+/*!
+\file conservation_laws_passive.hh
+\brief Declares rules for a passively advected scalar (PAS)
+\author Vladimir Florinski
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
+*/
+
+#ifndef SPECTRUM_CONSERVATION_LAWS_PASSIVE_HH
+#define SPECTRUM_CONSERVATION_LAWS_PASSIVE_HH
+
+#include "common/vectors.hh"
+
+namespace Spectrum {
+
+//! Number of fluid variables
+#define CL_PASSIVE_NVARS 1
+
+/*!
+\brief Codifies physics of passively advected scalar
+\author Vladimir Florinski
+*/
+class Passive
+{
+public:
+
+   struct ConservedState;
+   struct FluxFunction;
+
+//! A trait to be used in template specializations
+   static constexpr bool is_cons_law_active = false;
+
+//! Return the number of variables
+   SPECTRUM_DEVICE_FUNC static constexpr int Nvars(void) {return CL_PASSIVE_NVARS;};
+
+/*!
+\brief Codifies physics of passively advected scalar for primitive variables
+\author Vladimir Florinski
+*/
+   struct PrimitiveState : public SimpleArray<double, CL_PASSIVE_NVARS>
+   {
+      using SimpleArray<double, CL_PASSIVE_NVARS>::data;
+
+   //! Alias for PAS (RO)
+      const double& pas(void) const {return data[0];};
+
+   //! Alias for PAS (RW)
+      double& pas(void) {return data[0];};
+
+   //! Default constructor
+      SPECTRUM_DEVICE_FUNC PrimitiveState(void) = default;
+
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC PrimitiveState(double pas_in);
+
+   //! Constructor from SimpleArray
+      SPECTRUM_DEVICE_FUNC PrimitiveState(const SimpleArray<double, CL_PASSIVE_NVARS>& other);
+
+   //! Calculate conserved state
+      template <typename ActiveConsLaw, std::enable_if_t<ActiveConsLaw::is_cons_law_active, bool> = true>
+      SPECTRUM_DEVICE_FUNC ConservedState ToConserved(const ActiveConsLaw::PrimitiveState& active_prim) const;
+
+   //! Calculate flux function
+      template <typename ActiveConsLaw, std::enable_if_t<ActiveConsLaw::is_cons_law_active, bool> = true>
+      SPECTRUM_DEVICE_FUNC FluxFunction ToFlux(const ActiveConsLaw::PrimitiveState& active_prim) const;
+   };
+
+/*!
+\brief Codifies physics of passively advected scalar for conserved variables
+\author Vladimir Florinski
+*/
+   struct ConservedState : public SimpleArray<double, CL_PASSIVE_NVARS>
+   {
+      using SimpleArray<double, CL_PASSIVE_NVARS>::data;
+
+   //! Alias for primary density*PAS (RO)
+      const double& dpas(void) const {return data[0];};
+
+   //! Alias for primary density*PAS (RW)
+      double& dpas(void) {return data[0];};
+
+   //! Default constructor
+      SPECTRUM_DEVICE_FUNC ConservedState(void) = default;
+
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC ConservedState(double dpas_in);
+
+   //! Constructor from SimpleArray
+      SPECTRUM_DEVICE_FUNC ConservedState(const SimpleArray<double, CL_PASSIVE_NVARS>& other);
+
+   //! Calculate primitive state
+      template <typename ActiveConsLaw, std::enable_if_t<ActiveConsLaw::is_cons_law_active, bool> = true>
+      SPECTRUM_DEVICE_FUNC PrimitiveState ToPrimitive(const ActiveConsLaw::PrimitiveState& active_prim) const;
+
+   //! Calculate flux function
+      template <typename ActiveConsLaw, std::enable_if_t<ActiveConsLaw::is_cons_law_active, bool> = true>
+      SPECTRUM_DEVICE_FUNC FluxFunction ToFlux(const ActiveConsLaw::PrimitiveState& active_prim) const;
+   };
+
+/*!
+\brief Codifies physics of passively advected scalar for the fluxes
+\author Vladimir Florinski
+*/
+   struct FluxFunction : public SimpleArray<double, CL_PASSIVE_NVARS>
+   {
+      using SimpleArray<double, CL_PASSIVE_NVARS>::data;
+
+   //! Alias for primary density*PAS flux (RO)
+      const double& dpasf(void) const {return data[0];};
+
+   //! Alias for primary density*PAS flux (RW)
+      double& dpasf(void) {return data[0];};
+
+   //! Default constructor
+      SPECTRUM_DEVICE_FUNC FluxFunction(void) = default;
+
+   //! Constructor from components
+      SPECTRUM_DEVICE_FUNC FluxFunction(double dpasf_in);
+
+   //! Constructor from SimpleArray
+      SPECTRUM_DEVICE_FUNC FluxFunction(const SimpleArray<double, CL_PASSIVE_NVARS>& other);
+   };
+
+};
+
+};
+
+#endif

--- a/fluid/riemann_solver.cc
+++ b/fluid/riemann_solver.cc
@@ -1,0 +1,293 @@
+/*!
+\file riemann_solver.cc
+\brief Implements several common one-dimensional Riemann solvers
+\author Vladimir Florinski
+\author XiaoCheng Guo
+\author Dinshaw Balsara
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
+*/
+
+#include "fluid/riemann_solver.hh"
+#ifdef GEO_DEBUG
+#include "common/print_warn.hh"
+#endif
+
+namespace Spectrum {
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// RiemannSolverBase methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\params[in] left_prim_in Left primitive state
+\params[in] rght_prim_in Right primitive state
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC void RiemannSolverBase<ConsLaw>::Solve(const ConsLaw::PrimitiveState& left_prim_in, const ConsLaw::PrimitiveState& rght_prim_in)
+{
+   left_prim = left_prim_in;
+   rght_prim = rght_prim_in;
+   left_cons = left_prim.ToConserved(false);
+   rght_cons = rght_prim.ToConserved(false);
+   left_flux = left_prim.ToFlux(false);
+   rght_flux = rght_prim.ToFlux(false);
+   SolveInternal();
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\params[in] left_cons_in Left conserved state
+\params[in] rght_cons_in Right conserved state
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC void RiemannSolverBase<ConsLaw>::Solve(const ConsLaw::ConservedState& left_cons_in, const ConsLaw::ConservedState& rght_cons_in)
+{
+   left_cons = left_cons_in;
+   rght_cons = rght_cons_in;
+   left_prim = left_cons.ToPrimitive(false);
+   rght_prim = rght_cons.ToPrimitive(false);
+   left_flux = left_prim.ToFlux(false);
+   rght_flux = rght_prim.ToFlux(false);
+   SolveInternal();
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Resolved primitive state
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC ConsLaw::PrimitiveState RiemannSolverBase<ConsLaw>::GetResolvedPrim(void) const
+{
+   return resv_prim;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Resolved conserved state
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC ConsLaw::ConservedState RiemannSolverBase<ConsLaw>::GetResolvedCons(void) const
+{
+   return resv_cons;
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+\return Resolved flux function
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC ConsLaw::FluxFunction RiemannSolverBase<ConsLaw>::GetResolvedFlux(void) const
+{
+   return resv_flux;
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// RiemannSolverRusanov methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC void RiemannSolverRusanov<ConsLaw>::SolveInternal(void)
+{
+   double fastest_wave_left = left_prim.FastestWaveNormal();
+   double fastest_wave_rght = rght_prim.FastestWaveNormal();
+   S = std::max(std::abs(left_prim.vel[0]) + fastest_wave_left, std::abs(rght_prim.vel[0]) + fastest_wave_rght);
+
+   resv_cons = 0.5 * (left_flux - rght_flux + S * (left_cons + rght_cons)) / S;
+   resv_prim = resv_cons.ToPrimitive(false);
+   resv_flux = 0.5 * (left_flux + rght_flux + S * (left_cons - rght_cons));
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// RiemannSolverHLLE methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC void RiemannSolverHLLE<ConsLaw>::IterateStarState(void)
+{
+#ifdef GEO_DEBUG
+   int iter_count = 0;
+#endif
+   double SLStar, SRStar, fastest_wave_star;
+
+   do {
+      resv_cons = (SR * rght_cons - SL * left_cons - rght_flux + left_flux) / (SR - SL);
+      resv_prim = resv_cons.ToPrimitive(false);
+      fastest_wave_star = resv_prim.FastestWaveNormal();
+
+      SLStar = resv_prim.vel[0] - fastest_wave_star;
+      SRStar = resv_prim.vel[0] + fastest_wave_star;
+
+      if((SLStar - SL >= 0.0) && (SR - SRStar >= 0.0)) break;
+      SL = std::min(SL, SLStar);
+      SR = std::max(SR, SRStar);
+
+#ifdef GEO_DEBUG
+      iter_count++;
+#endif
+   } while(true);
+   
+#ifdef GEO_DEBUG
+   PrintMessage(__FILE__, __LINE__, std::to_string(iter_count) + " HLL iterations performed", true);
+#endif
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+
+Ref: Einfeldt, B., On Godunov-type methods for gas dynamics, SIAM Journal on Numerical Analysis, v. 25, p. 294 (1988).
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC void RiemannSolverHLLE<ConsLaw>::SolveInternal(void)
+{
+   double fastest_wave_left = left_prim.FastestWaveNormal();
+   double fastest_wave_rght = rght_prim.FastestWaveNormal();
+
+   SL = std::min(left_prim.vel()[0] - fastest_wave_left, rght_prim.vel()[0] - fastest_wave_rght);
+   SR = std::max(left_prim.vel()[0] + fastest_wave_left, rght_prim.vel()[0] + fastest_wave_rght);
+
+#if ITERATE_HLL_WAVE != 0
+// Move the extremal waves as far as possible
+   IterateStarState();
+#endif
+
+// Supersonic flow to the left, use the right state
+   if(SR <= 0.0) {
+      resv_cons = rght_cons;
+      resv_flux = rght_prim.ToFlux(false);
+      resv_prim = rght_prim;
+   }
+
+// Supersonic flow to the right, use the left state
+   else if(SL >= 0.0) {
+      resv_cons = left_cons;
+      resv_flux = left_prim.ToFlux(false);
+      resv_prim = left_prim;
+   }
+
+// Riemann fan is open - calculate the intermediate state and flux
+   else {
+      prime_flux_left = SL * left_cons - left_flux;
+      prime_flux_rght = SR * rght_cons - rght_flux;
+      resv_cons = (prime_flux_rght - prime_flux_left) / (SR - SL);
+      resv_prim = resv_cons.ToPrimitive(false);
+      resv_flux = (SR * left_flux - SL * rght_flux + SR * SL * (rght_cons - left_cons)) / (SR - SL);
+   };   
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// RiemannSolverHLLC methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+
+Ref: Li, S., An HLLC Riemann Solver for Magneto-Hydrodynamics, Journal of Computational Physics, v. 203, p. 344 (2005).
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC void RiemannSolverHLLC<ConsLaw>::SolveInternal(void)
+{
+   double resv_total_pre;
+
+// Call the parent version
+   RiemannSolverHLLE<ConsLaw>::SolveInternal();
+
+// Keep the HLLE result for supersonic flows
+   if(SL * SR >= 0.0) return;
+
+// For transsonic flows some work was already done in the parent function, namely V1,V5,V6,V7,U5,U6,U7
+   SC = resv_prim.vel()[0];
+
+// Intermediate speed to the right - compute the left intermediate state
+   if(SC > 0.0) {
+      resv_prim.den() = prime_flux_left.den() / (SL - SC); // V0
+      resv_cons.mom()[0] = resv_prim.den() * SC; // U1
+      resv_cons.FixEnergy(prime_flux_left, SL, SC); // U4
+      resv_cons.den() = resv_prim.den(); // U0
+      resv_cons.FixMomentum(prime_flux_left, SL, SC); // U2,U3
+      resv_prim.vel()[1] = resv_cons.mom()[1] / resv_prim.den(); // V2
+      resv_prim.vel()[2] = resv_cons.mom()[2] / resv_prim.den(); // V3
+      resv_prim.pre() = resv_cons.GetPressure(); // V4
+      resv_flux = left_flux - SL * (left_cons - resv_cons);
+   }
+
+// Intermediate speed to the left - compute the right intermediate state
+   else {
+      resv_prim.den() = prime_flux_rght.den() / (SR - SC); // V0
+      resv_cons.mom()[0] = resv_prim.den() * SC; // U1
+      resv_cons.FixEnergy(prime_flux_rght, SR, SC); // U4
+      resv_cons.den() = resv_prim.den(); // U0
+      resv_cons.FixMomentum(prime_flux_rght, SR, SC); // U2,U3
+      resv_prim.vel()[1] = resv_cons.mom()[1] / resv_prim.den(); // V2
+      resv_prim.vel()[2] = resv_cons.mom()[2] / resv_prim.den(); // V3
+      resv_prim.pre() = resv_cons.GetPressure(); // V4
+      resv_flux = rght_flux - SR * (rght_cons - resv_cons);
+   };   
+
+// Test for small pressure and possibly revert to HLLE
+   if(resv_prim.pre() / resv_cons.enr() < sp_tiny) {
+      RiemannSolverHLLE<ConsLaw>::SolveInternal();
+#ifdef GEO_DEBUG
+      PrintMessage(__FILE__, __LINE__, "HLLC solver pressure underflow, reverting to HLLE", true);
+#endif
+   };
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// RiemannSolverNoreflect methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Vladimir Florinski
+\date 01/15/2025
+*/
+template<typename ConsLaw>
+SPECTRUM_DEVICE_FUNC void RiemannSolverNoreflect<ConsLaw>::SolveInternal(void)
+{
+   double fastest_wave_left = left_prim.FastestWaveNormal();
+   double fastest_wave_rght = rght_prim.FastestWaveNormal();
+
+// Revert to the backup RS (HLLE) for inflow, super-luminal outflow, or sub-luminal BC
+   if(dir > 0.0) {
+      if((left_prim.vel()[0] < 0.0) || (fastest_wave_left - left_prim.vel()[0] < 0.0) || (fastest_wave_rght - rght_prim.vel()[0] > 0.0)) {
+         RiemannSolverHLLE<ConsLaw>::SolveInternal();
+         return;
+      };
+   }
+   else {
+      if((rght_prim.vel()[0] > 0.0) || (fastest_wave_rght + rght_prim.vel()[0] < 0.0) || (fastest_wave_left + left_prim.vel()[0] > 0.0)) {
+         RiemannSolverHLLE<ConsLaw>::SolveInternal();
+         return;
+      };
+   };
+
+// Obtain the sonic state. The standard situation is the interior cell on the left and the ghost cell on the right. For the opposite case all vector quantities must be inverted on input to "ToSonic()" and then inverted back.
+   if(dir > 0.0) resv_prim = left_prim.ToSonic(false);
+   else {
+      rght_prim.Invert();
+      resv_prim = rght_prim.ToSonic(false);
+      rght_prim.Invert();
+      resv_prim.Invert();
+   };
+
+   resv_cons = resv_prim.ToConserved(false);
+   resv_flux = resv_prim.ToFlux(false);
+};
+
+};

--- a/fluid/riemann_solver.hh
+++ b/fluid/riemann_solver.hh
@@ -13,9 +13,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 
 #include "fluid/conservation_laws_gasdyn.hh"
 #include "fluid/conservation_laws_mhd.hh"
-#ifdef GEO_DEBUG
-#include "common/print_warn.hh"
-#endif
 
 namespace Spectrum {
 
@@ -30,37 +27,37 @@ namespace Spectrum {
 \brief Riemann solver base class template
 \author Vladimir Florinski
 */
-template<typename cl_prim, typename cl_cons, typename cl_flux>
+template<typename ConsLaw>
 class RiemannSolverBase
 {
 protected:
 
 //! Left primitive state
-   cl_prim left_prim;
+   ConsLaw::PrimitiveState left_prim;
 
 //! Right primitive state
-   cl_cons rght_prim;
+   ConsLaw::PrimitiveState rght_prim;
 
 //! Resolved primitive state
-   cl_prim resv_prim;
+   ConsLaw::PrimitiveState resv_prim;
 
 //! Left conserved state
-   cl_cons left_cons;
+   ConsLaw::ConservedState left_cons;
 
 //! Right conserved state
-   cl_cons rght_cons;
+   ConsLaw::ConservedState rght_cons;
 
 //! Resolved conserved state
-   cl_cons resv_cons;
+   ConsLaw::ConservedState resv_cons;
 
 //! Left flux function
-   cl_flux left_flux;
+   ConsLaw::FluxFunction left_flux;
 
 //! Right flux function
-   cl_flux rght_flux;
+   ConsLaw::FluxFunction rght_flux;
 
 //! Resolved flux function
-   cl_flux resv_flux;
+   ConsLaw::FluxFunction resv_flux;
 
 //! Internal solver for the Riemann problem
    SPECTRUM_DEVICE_FUNC virtual void SolveInternal(void) {};
@@ -71,88 +68,19 @@ public:
    SPECTRUM_DEVICE_FUNC RiemannSolverBase(void) = default;
 
 //! Solve the Riemann problem using primitive reconstruction
-   SPECTRUM_DEVICE_FUNC void Solve(const cl_prim& left_prim_in, const cl_prim& rght_prim_in);
+   SPECTRUM_DEVICE_FUNC void Solve(const ConsLaw::PrimitiveState& left_prim_in, const ConsLaw::PrimitiveState& rght_prim_in);
 
 //! Solve the Riemann problem using conserved reconstruction
-   SPECTRUM_DEVICE_FUNC void Solve(const cl_cons& left_cons_in, const cl_cons& rght_cons_in);
+   SPECTRUM_DEVICE_FUNC void Solve(const ConsLaw::ConservedState& left_cons_in, const ConsLaw::ConservedState& rght_cons_in);
 
 //! Return the resolved primitive state
-   SPECTRUM_DEVICE_FUNC cl_prim GetResolvedPrim(void) const;
+   SPECTRUM_DEVICE_FUNC ConsLaw::PrimitiveState GetResolvedPrim(void) const;
 
 //! Return the resolved conserved state
-   SPECTRUM_DEVICE_FUNC cl_cons GetResolvedCons(void) const;
+   SPECTRUM_DEVICE_FUNC ConsLaw::ConservedState GetResolvedCons(void) const;
 
 //! Return the resolved flux function
-   SPECTRUM_DEVICE_FUNC cl_flux GetResolvedFlux(void) const;
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/18/2024
-\params[in] left_prim_in Left primitive state
-\params[in] rght_prim_in Right primitive state
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline void RiemannSolverBase<cl_prim, cl_cons, cl_flux>::Solve(const cl_prim& left_prim_in, const cl_prim& rght_prim_in)
-{
-   left_prim = left_prim_in;
-   rght_prim = rght_prim_in;
-   left_cons = left_prim.ToConserved(false);
-   rght_cons = rght_prim.ToConserved(false);
-   left_flux = left_prim.ToFlux(false);
-   rght_flux = rght_prim.ToFlux(false);
-   SolveInternal();
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/18/2024
-\params[in] left_cons_in Left conserved state
-\params[in] rght_cons_in Right conserved state
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline void RiemannSolverBase<cl_prim, cl_cons, cl_flux>::Solve(const cl_cons& left_cons_in, const cl_cons& rght_cons_in)
-{
-   left_cons = left_cons_in;
-   rght_cons = rght_cons_in;
-   left_prim = left_cons.ToPrimitive(false);
-   rght_prim = rght_cons.ToPrimitive(false);
-   left_flux = left_prim.ToFlux(false);
-   rght_flux = rght_prim.ToFlux(false);
-   SolveInternal();
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/07/2024
-\return Resolved primitive state
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline cl_prim RiemannSolverBase<cl_prim, cl_cons, cl_flux>::GetResolvedPrim(void) const
-{
-   return resv_prim;
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/18/2024
-\return Resolved conserved state
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline cl_cons RiemannSolverBase<cl_prim, cl_cons, cl_flux>::GetResolvedCons(void) const
-{
-   return resv_cons;
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/07/2024
-\return Resolved flux function
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline cl_flux RiemannSolverBase<cl_prim, cl_cons, cl_flux>::GetResolvedFlux(void) const
-{
-   return resv_flux;
+   SPECTRUM_DEVICE_FUNC ConsLaw::FluxFunction GetResolvedFlux(void) const;
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -163,18 +91,18 @@ SPECTRUM_DEVICE_FUNC inline cl_flux RiemannSolverBase<cl_prim, cl_cons, cl_flux>
 \brief Rusanov Riemann solver class template
 \author Vladimir Florinski
 */
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-class RiemannSolverRusanov : public RiemannSolverBase<cl_prim, cl_cons, cl_flux>
+template<typename ConsLaw>
+class RiemannSolverRusanov : public RiemannSolverBase<ConsLaw>
 {
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_flux;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_flux;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_flux;
+   using RiemannSolverBase<ConsLaw>::left_prim;
+   using RiemannSolverBase<ConsLaw>::rght_prim;
+   using RiemannSolverBase<ConsLaw>::resv_prim;
+   using RiemannSolverBase<ConsLaw>::left_cons;
+   using RiemannSolverBase<ConsLaw>::rght_cons;
+   using RiemannSolverBase<ConsLaw>::resv_cons;
+   using RiemannSolverBase<ConsLaw>::left_flux;
+   using RiemannSolverBase<ConsLaw>::rght_flux;
+   using RiemannSolverBase<ConsLaw>::resv_flux;
 
 protected:
 
@@ -190,22 +118,6 @@ public:
    SPECTRUM_DEVICE_FUNC RiemannSolverRusanov(void) = default;
 };
 
-/*!
-\author Vladimir Florinski
-\date 03/18/2024
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline void RiemannSolverRusanov<cl_prim, cl_cons, cl_flux>::SolveInternal(void)
-{
-   double fastest_wave_left = left_prim.FastestWaveNormal();
-   double fastest_wave_rght = rght_prim.FastestWaveNormal();
-   S = std::max(std::abs(left_prim.vel[0]) + fastest_wave_left, std::abs(rght_prim.vel[0]) + fastest_wave_rght);
-
-   resv_cons = 0.5 * (left_flux - rght_flux + S * (left_cons + rght_cons)) / S;
-   resv_prim = resv_cons.ToPrimitive(false);
-   resv_flux = 0.5 * (left_flux + rght_flux + S * (left_cons - rght_cons));
-};
-
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 // RiemannSolverHLLE class declaration
 //----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -214,18 +126,18 @@ SPECTRUM_DEVICE_FUNC inline void RiemannSolverRusanov<cl_prim, cl_cons, cl_flux>
 \brief HLLE Riemann solver class template
 \author Vladimir Florinski
 */
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-class RiemannSolverHLLE : public RiemannSolverBase<cl_prim, cl_cons, cl_flux>
+template<typename ConsLaw>
+class RiemannSolverHLLE : public RiemannSolverBase<ConsLaw>
 {
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_flux;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_flux;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_flux;
+   using RiemannSolverBase<ConsLaw>::left_prim;
+   using RiemannSolverBase<ConsLaw>::rght_prim;
+   using RiemannSolverBase<ConsLaw>::resv_prim;
+   using RiemannSolverBase<ConsLaw>::left_cons;
+   using RiemannSolverBase<ConsLaw>::rght_cons;
+   using RiemannSolverBase<ConsLaw>::resv_cons;
+   using RiemannSolverBase<ConsLaw>::left_flux;
+   using RiemannSolverBase<ConsLaw>::rght_flux;
+   using RiemannSolverBase<ConsLaw>::resv_flux;
 
 protected:
 
@@ -236,10 +148,10 @@ protected:
    double SR;
 
 //! Left flux in the moving frame
-   cl_flux prime_flux_left;
+   ConsLaw::FluxFunction prime_flux_left;
 
 //! Right flux in the moving frame
-   cl_flux prime_flux_rght;
+   ConsLaw::FluxFunction prime_flux_rght;
 
 //! Iterate to find the extremal speeds SL and SR
    SPECTRUM_DEVICE_FUNC void IterateStarState(void);
@@ -253,82 +165,6 @@ public:
    SPECTRUM_DEVICE_FUNC RiemannSolverHLLE(void) = default;
 };
 
-/*!
-\author Vladimir Florinski
-\date 03/20/2024
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline void RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::IterateStarState(void)
-{
-#ifdef GEO_DEBUG
-   int iter_count = 0;
-#endif
-   double SLStar, SRStar, fastest_wave_star;
-
-   do {
-      resv_cons = (SR * rght_cons - SL * left_cons - rght_flux + left_flux) / (SR - SL);
-      resv_prim = resv_cons.ToPrimitive(false);
-      fastest_wave_star = resv_prim.FastestWaveNormal();
-
-      SLStar = resv_prim.vel[0] - fastest_wave_star;
-      SRStar = resv_prim.vel[0] + fastest_wave_star;
-
-      if((SLStar - SL >= 0.0) && (SR - SRStar >= 0.0)) break;
-      SL = std::min(SL, SLStar);
-      SR = std::max(SR, SRStar);
-
-#ifdef GEO_DEBUG
-      iter_count++;
-#endif
-   } while(true);
-   
-#ifdef GEO_DEBUG
-   PrintMessage(__FILE__, __LINE__, std::to_string(iter_count) + " HLL iterations performed", true);
-#endif
-};
-
-/*!
-\author Vladimir Florinski
-\date 03/18/2024
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline void RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::SolveInternal(void)
-{
-   double fastest_wave_left = left_prim.FastestWaveNormal();
-   double fastest_wave_rght = rght_prim.FastestWaveNormal();
-
-   SL = std::min(left_prim.vel()[0] - fastest_wave_left, rght_prim.vel()[0] - fastest_wave_rght);
-   SR = std::max(left_prim.vel()[0] + fastest_wave_left, rght_prim.vel()[0] + fastest_wave_rght);
-
-#if ITERATE_HLL_WAVE != 0
-// Move the extremal waves as far as possible
-   IterateStarState();
-#endif
-
-// Supersonic flow to the left, use the right state
-   if(SR <= 0.0) {
-      resv_cons = rght_cons;
-      resv_flux = rght_prim.ToFlux(false);
-      resv_prim = rght_prim;
-   }
-
-// Supersonic flow to the right, use the left state
-   else if(SL >= 0.0) {
-      resv_cons = left_cons;
-      resv_flux = left_prim.ToFlux(false);
-      resv_prim = left_prim;
-   }
-
-// Riemann fan is open - calculate the intermediate state and flux
-   else {
-      prime_flux_left = SL * left_cons - left_flux;
-      prime_flux_rght = SR * rght_cons - rght_flux;
-      resv_cons = (prime_flux_rght - prime_flux_left) / (SR - SL);
-      resv_prim = resv_cons.ToPrimitive(false);
-      resv_flux = (SR * left_flux - SL * rght_flux + SR * SL * (rght_cons - left_cons)) / (SR - SL);
-   };   
-};
-
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 // RiemannSolverHLLC class declaration
 //----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -337,24 +173,24 @@ SPECTRUM_DEVICE_FUNC inline void RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::S
 \brief HLLC Riemann solver class template
 \author Vladimir Florinski
 */
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-class RiemannSolverHLLC : public RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>
+template<typename ConsLaw>
+class RiemannSolverHLLC : public RiemannSolverHLLE<ConsLaw>
 {
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_flux;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_flux;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_flux;
+   using RiemannSolverBase<ConsLaw>::left_prim;
+   using RiemannSolverBase<ConsLaw>::rght_prim;
+   using RiemannSolverBase<ConsLaw>::resv_prim;
+   using RiemannSolverBase<ConsLaw>::left_cons;
+   using RiemannSolverBase<ConsLaw>::rght_cons;
+   using RiemannSolverBase<ConsLaw>::resv_cons;
+   using RiemannSolverBase<ConsLaw>::left_flux;
+   using RiemannSolverBase<ConsLaw>::rght_flux;
+   using RiemannSolverBase<ConsLaw>::resv_flux;
 
-   using RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::SL;
-   using RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::SR;
-   using RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::prime_flux_left;
-   using RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::prime_flux_rght;
-   using RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::IterateStarState;
+   using RiemannSolverHLLE<ConsLaw>::SL;
+   using RiemannSolverHLLE<ConsLaw>::SR;
+   using RiemannSolverHLLE<ConsLaw>::prime_flux_left;
+   using RiemannSolverHLLE<ConsLaw>::prime_flux_rght;
+   using RiemannSolverHLLE<ConsLaw>::IterateStarState;
 
 protected:
 
@@ -370,61 +206,6 @@ public:
    SPECTRUM_DEVICE_FUNC RiemannSolverHLLC(void) = default;
 };
 
-/*!
-\author Vladimir Florinski
-\date 03/20/2024
-
-Ref: Li, S., An HLLC Riemann Solver for Magneto-Hydrodynamics, Journal of Computational Physics, v. 203, p. 344 (2005).
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline void RiemannSolverHLLC<cl_prim, cl_cons, cl_flux>::SolveInternal(void)
-{
-   double resv_total_pre;
-
-// Call the parent version
-   RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::SolveInternal();
-
-// Keep the HLLE result for supersonic flows
-   if(SL * SR >= 0.0) return;
-
-// For transsonic flows some work was already done in the parent function, namely V1,V5,V6,V7,U5,U6,U7
-   SC = resv_prim.vel()[0];
-
-// Intermediate speed to the right - compute the left intermediate state
-   if(SC > 0.0) {
-      resv_prim.den() = prime_flux_left.den() / (SL - SC); // V0
-      resv_cons.mom()[0] = resv_prim.den() * SC; // U1
-      resv_cons.FixEnergy(prime_flux_left, SL, SC); // U4
-      resv_cons.den() = resv_prim.den(); // U0
-      resv_cons.FixMomentum(prime_flux_left, SL, SC); // U2,U3
-      resv_prim.vel()[1] = resv_cons.mom()[1] / resv_prim.den(); // V2
-      resv_prim.vel()[2] = resv_cons.mom()[2] / resv_prim.den(); // V3
-      resv_prim.pre() = resv_cons.GetPressure(); // V4
-      resv_flux = left_flux - SL * (left_cons - resv_cons);
-   }
-
-// Intermediate speed to the left - compute the right intermediate state
-   else {
-      resv_prim.den() = prime_flux_rght.den() / (SR - SC); // V0
-      resv_cons.mom()[0] = resv_prim.den() * SC; // U1
-      resv_cons.FixEnergy(prime_flux_rght, SR, SC); // U4
-      resv_cons.den() = resv_prim.den(); // U0
-      resv_cons.FixMomentum(prime_flux_rght, SR, SC); // U2,U3
-      resv_prim.vel()[1] = resv_cons.mom()[1] / resv_prim.den(); // V2
-      resv_prim.vel()[2] = resv_cons.mom()[2] / resv_prim.den(); // V3
-      resv_prim.pre() = resv_cons.GetPressure(); // V4
-      resv_flux = rght_flux - SR * (rght_cons - resv_cons);
-   };   
-
-// Test for small pressure and possibly revert to HLLE
-   if(resv_prim.pre() / resv_cons.enr() < tiny) {
-      RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::SolveInternal();
-#ifdef GEO_DEBUG
-      PrintMessage(__FILE__, __LINE__, "HLLC solver pressure underflow, reverting to HLLE", true);
-#endif
-   };
-};
-
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 // RiemannSolverNoreflect class declaration
 //----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -435,18 +216,18 @@ SPECTRUM_DEVICE_FUNC inline void RiemannSolverHLLC<cl_prim, cl_cons, cl_flux>::S
 
 Ref: Pogorelov, N. V., and Semenov, A. Y., Solar Wind Interaction with the Magnetized Interstellar Medium, Astronomy and Astrophysics, v. 321, p. 330 (1997).
 */
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-class RiemannSolverNoreflect : public RiemannSolverBase<cl_prim, cl_cons, cl_flux>
+template<typename ConsLaw>
+class RiemannSolverNoreflect : public RiemannSolverBase<ConsLaw>
 {
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_prim;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_cons;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::left_flux;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::rght_flux;
-   using RiemannSolverBase<cl_prim, cl_cons, cl_flux>::resv_flux;
+   using RiemannSolverBase<ConsLaw>::left_prim;
+   using RiemannSolverBase<ConsLaw>::rght_prim;
+   using RiemannSolverBase<ConsLaw>::resv_prim;
+   using RiemannSolverBase<ConsLaw>::left_cons;
+   using RiemannSolverBase<ConsLaw>::rght_cons;
+   using RiemannSolverBase<ConsLaw>::resv_cons;
+   using RiemannSolverBase<ConsLaw>::left_flux;
+   using RiemannSolverBase<ConsLaw>::rght_flux;
+   using RiemannSolverBase<ConsLaw>::resv_flux;
 
 protected:
 
@@ -463,43 +244,6 @@ public:
 
 //! Default constructor
    SPECTRUM_DEVICE_FUNC RiemannSolverNoreflect(void) = default;
-};
-
-/*!
-\author Vladimir Florinski
-\date 04/09/2024
-*/
-template<typename cl_prim, typename cl_cons, typename cl_flux>
-SPECTRUM_DEVICE_FUNC inline void RiemannSolverNoreflect<cl_prim, cl_cons, cl_flux>::SolveInternal(void)
-{
-   double fastest_wave_left = left_prim.FastestWaveNormal();
-   double fastest_wave_rght = rght_prim.FastestWaveNormal();
-
-// Revert to the backup RS (HLLE) for inflow, super-luminal outflow, or sub-luminal BC
-   if(dir > 0.0) {
-      if((left_prim.vel()[0] < 0.0) || (fastest_wave_left - left_prim.vel()[0] < 0.0) || (fastest_wave_rght - rght_prim.vel()[0] > 0.0)) {
-         RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::SolveInternal();
-         return;
-      };
-   }
-   else {
-      if((rght_prim.vel()[0] > 0.0) || (fastest_wave_rght + rght_prim.vel()[0] < 0.0) || (fastest_wave_left + left_prim.vel()[0] > 0.0)) {
-         RiemannSolverHLLE<cl_prim, cl_cons, cl_flux>::SolveInternal();
-         return;
-      };
-   };
-
-// Obtain the sonic state
-   if(dir > 0.0) resv_prim = left_prim.ToSonic(false);
-   else {
-      rght_prim.Invert();
-      resv_prim = rght_prim.ToSonic(false);
-      rght_prim.Invert();
-      resv_prim.Invert();
-   };
-
-   resv_cons = resv_prim.ToConserved(false);
-   resv_flux = resv_prim.ToFlux(false);
 };
 
 };

--- a/fluid/variables.hh
+++ b/fluid/variables.hh
@@ -1,0 +1,136 @@
+/*!
+\file variables.hh
+\brief A container class for multiple fluid variables
+\author Vladimir Florinski
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
+*/
+
+#ifndef SPECTRUM_VARIABLES
+#define SPECTRUM_VARIABLES
+
+#include "config.h"
+#include "common/physics.hh"
+
+// Possible fluid types:
+// GASDYN - compressible gas dynamics (5 vars)
+// MHD - ideal MHD (8 vars)
+// MHDE - two-fluid ideal MHD (9 vars)
+// CGL - anisotropic ideal MHD (9 vars)
+// CGLE - anisotropic two-fluid ideal MHD (9 vars)
+
+// TODO: These should go into config.h
+#define FLUID_GASDYN 301
+#define FLUID_MHD    302
+#define FLUID_MHDE   303
+#define FLUID_CGL    304
+#define FLUID_CGLE   305
+#define TURB_ZANK6EQ 321
+
+#define PASSIVE_PRIMARY_01
+#define PASSIVE_PRIMARY_02
+
+#define FLUID_PRIMARY_TYPE FLUID_MHD
+#define FLUID_PRIMARY_SPECIE Specie::proton
+
+#define FLUID_SECONDARY_TYPE FLUID_GASDYN
+#define FLUID_SECONDARY_SPECIE Specie::proton
+
+#define FLUID_TERTIARY_TYPE FLUID_GASDYN
+#define FLUID_TERTIARY_SPECIE Specie::proton
+
+#undef FLUID_QUATERNARY_TYPE
+#undef FLUID_QUATERNARY_SPECIE
+
+#undef TURBULENCE_TYPE
+
+#if (FLUID_PRIMARY_TYPE == FLUID_GASDYN) || (FLUID_SECONDARY_TYPE == FLUID_GASDYN) || (FLUID_TERTIARY_TYPE == FLUID_GASDYN) || (FLUID_QUATERNARY_TYPE == FLUID_GASDYN)
+#include "fluid/conservation_laws_gasdyn.hh"
+#endif
+
+#if (FLUID_PRIMARY_TYPE == FLUID_MHD) || (FLUID_SECONDARY_TYPE == FLUID_MHD) || (FLUID_TERTIARY_TYPE == FLUID_MHD) || (FLUID_QUATERNARY_TYPE == FLUID_MHD)
+#include "fluid/conservation_laws_mhd.hh"
+#endif
+
+#if TURBULENCE_TYPE == TURB_ZANK6EQ
+#include "fluid/conservation_laws_zank6eq.hh"
+#endif
+
+#if defined(PASSIVE_PRIMARY_01) || defined(PASSIVE_PRIMARY_02) || defined(PASSIVE_SECONDARY_01) || defined (PASSIVE_SECONDARY_02)
+#include "fluid/conservation_laws_passive.hh"
+#endif
+
+namespace Spectrum {
+
+/*!
+\brief A container combining all conserved fluid variables into single contiguous storage
+\author Vladimir Florinski
+*/
+struct ConservedVariables
+{
+
+#if FLUID_PRIMARY_TYPE == FLUID_GASDYN
+   Gasdyn<FLUID_PRIMARY_SPECIE>::ConservedState var_primary;
+#elif FLUID_PRIMARY_TYPE == FLUID_MHD
+   MHD<FLUID_PRIMARY_SPECIE>::ConservedState var_primary;
+#endif
+
+#ifdef PASSIVE_PRIMARY_01
+   Passive::ConservedState passive_primary_01;
+#endif
+
+#ifdef PASSIVE_PRIMARY_02
+   Passive::ConservedState passive_primary_02;
+#endif
+
+#if FLUID_SECONDARY_TYPE == FLUID_GASDYN
+   Gasdyn<FLUID_SECONDARY_SPECIE>::ConservedState var_secondary;
+#elif FLUID_SECONDARY_TYPE == FLUID_MHD
+   MHD<FLUID_SECONDARY_SPECIE>::ConservedState var_secondary;
+#endif
+
+#ifdef PASSIVE_SECONDARY_01
+   Passive::ConservedState passive_secondary_01;
+#endif
+
+#ifdef PASSIVE_SECONDARY_02
+   Passive::ConservedState passive_secondary_02;
+#endif
+
+#if FLUID_TERTIARY_TYPE == FLUID_GASDYN
+   Gasdyn<FLUID_TERTIARY_SPECIE>::ConservedState var_tertiary;
+#elif FLUID_TERTIARY_TYPE == FLUID_MHD
+   MHD<FLUID_TERTIARY_SPECIE>::ConservedState var_tertiary;
+#endif
+
+#ifdef PASSIVE_TERTIARY_01
+   Passive::ConservedState passive_tertiary_01;
+#endif
+
+#ifdef PASSIVE_TERTIARY_02
+   Passive::ConservedState passive_tertiary_02;
+#endif
+
+#if FLUID_QUATERNARY_TYPE == FLUID_GASDYN
+   Gasdyn<FLUID_QUATERNARY_SPECIE>::ConservedState var_quaternary;
+#elif FLUID_QUATERNARY_TYPE == FLUID_MHD
+   MHD<FLUID_QUATERNARY_SPECIE>::ConservedState var_quaternary;
+#endif
+
+#ifdef PASSIVE_QUATERNARY_01
+   Passive::ConservedState passive_quaternary_01;
+#endif
+
+#ifdef PASSIVE_QUATERNARY_02
+   Passive::ConservedState passive_quaternary_02;
+#endif
+
+#if TURBULENCE_TYPE == TURB_ZANK6EQ
+   Zank6eq::ConservedState turbulence;
+#endif
+
+};
+
+};
+
+#endif

--- a/geodesic/buffered_block.cc
+++ b/geodesic/buffered_block.cc
@@ -6,6 +6,13 @@
 This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
 */
 
+#include <utility>
+
+#ifdef GEO_DEBUG
+#include <iostream>
+#include <iomanip>
+#endif
+
 #include "geodesic/buffered_block.hh"
 
 namespace Spectrum {
@@ -16,40 +23,142 @@ namespace Spectrum {
 
 /*!
 \author Vladimir Florinski
-\date 06/28/2024
-\param[in] other Object to initialize from
+\date 01/08/2025
 */
-template <int verts_per_face>
-BufferedBlock<verts_per_face>::BufferedBlock(const BufferedBlock& other)
-                             : StenciledBlock<verts_per_face>(static_cast<StenciledBlock<verts_per_face>>(other))
+template <int verts_per_face, typename datatype>
+BufferedBlock<verts_per_face, datatype>::BufferedBlock(void)
+                                       : StenciledBlock<verts_per_face>()
 {
-   if (other.side_length != -1) {
-      SetDimensions(other.side_length, other.ghost_width, other.n_shells, other.ghost_height, true);
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 3
+   std::cerr << "Default constructing a BufferedBlock\n";
+#endif
+#endif
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/08/2025
+\param[in] other Object to initialize from
+\note The copy constructor for "StenciledBlock" calls its "SetDimensions()" and "AssociateMesh()" methods
+*/
+template <int verts_per_face, typename datatype>
+BufferedBlock<verts_per_face, datatype>::BufferedBlock(const BufferedBlock& other)
+                                       : StenciledBlock<verts_per_face>(static_cast<const StenciledBlock<verts_per_face>&>(other))
+{
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 3
+   std::cerr << "Copy constructing a BufferedBlock\n";
+#endif
+#endif
+
+   if (other.side_length == -1) return;
+
+   SetDimensions(other.side_length, other.ghost_width, other.n_shells, other.ghost_height, true);
+   for (auto ntype = GEONBR_TFACE; ntype <= GEONBR_VERTX; GEO_INCR(ntype, NeighborType)) {
+      exch_sites[ntype] = other.exch_sites[ntype];
    };
 };
 
 /*!
 \author Vladimir Florinski
-\date 06/28/2024
+\date 01/08/2025
+\param[in] other Object to move into this
 */
-template <int verts_per_face>
-BufferedBlock<verts_per_face>::~BufferedBlock()
+template <int verts_per_face, typename datatype>
+BufferedBlock<verts_per_face, datatype>::BufferedBlock(BufferedBlock&& other)
+                                       : StenciledBlock<verts_per_face>(std::move(static_cast<StenciledBlock<verts_per_face>&&>(other)))
 {
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 3
+   std::cerr << "Move constructing a BufferedBlock\n";
+#endif
+#endif
+
+   if (other.side_length == -1) return;
+
+// Move the variables
+   zone_cons = other.zone_cons;
+   other.zone_cons = nullptr;
+
+// Move the exchange sites
+   std::memcpy(exch_site_count, other.exch_site_count, N_NBRTYPES * sizeof(int));
+   std::memcpy(default_part_per_site, other.default_part_per_site, N_NBRTYPES * sizeof(int));
+   for (auto ntype = GEONBR_TFACE; ntype <= GEONBR_VERTX; GEO_INCR(ntype, NeighborType)) {
+      exch_sites[ntype] = std::move(other.exch_sites[ntype]);
+   };
+   
+// Move the buffer maps
+   std::memcpy(buf_length, other.buf_length, N_NBRTYPES * sizeof(int));
+   std::memcpy(buf_width, other.buf_length, N_NBRTYPES * sizeof(int));
+   std::memcpy(buf_area, other.buf_length, N_NBRTYPES * sizeof(int));
+   std::memcpy(buf_height, other.buf_length, N_NBRTYPES * sizeof(int));
+   std::memcpy(buf_volume, other.buf_length, N_NBRTYPES * sizeof(int));
+   std::memcpy(buf_face_translation, other.buf_face_translation, N_NBRTYPES * sizeof(int***));
+   std::memcpy(buf_shell_tab, other.buf_shell_tab, 5 * sizeof(int));
+   std::memcpy(buf_shell_start, other.buf_shell_start, N_NBRTYPES * sizeof(int***));
+
+   for (auto ntype = GEONBR_TFACE; ntype <= GEONBR_VERTX; GEO_INCR(ntype, NeighborType)) {
+      other.buf_face_translation[ntype] = nullptr;
+      other.buf_shell_start[ntype] = nullptr;
+   };
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/08/2025
+\param[in] width  Length of the side, without ghost cells
+\param[in] wgohst Width of the ghost cell layer outside the sector
+\param[in] height Hight of the block, without ghost cells
+\param[in] hghost Number of ghost shells outside the slab
+*/
+template <int verts_per_face, typename datatype>
+BufferedBlock<verts_per_face, datatype>::BufferedBlock(int width, int wghost, int height, int hghost)
+                                       : StenciledBlock<verts_per_face>(width, wghost, height, hghost)
+{
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 3
+   std::cerr << "Argument constructing a BufferedBlock\n";
+#endif
+#endif
+
+   SetDimensions(width, wghost, height, hghost, true);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/08/2025
+*/
+template <int verts_per_face, typename datatype>
+BufferedBlock<verts_per_face, datatype>::~BufferedBlock()
+{
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 3
+   std::cerr << "Destructing a BufferedBlock\n";
+#endif
+#endif
+
    FreeStorage();
 };
 
 /*!
 \author Vladimir Florinski
-\date 12/23/2024
+\date 01/09/2025
 \param[in] width     Length of the side, without ghost cells
 \param[in] wghost    Width of the ghost cell layer outside the sector
 \param[in] height    Hight of the block, without ghost cells
 \param[in] hghost    Number of ghost shells outside the slab
 \param[in] construct Set to true when called from a constructor
 */
-template <int verts_per_face>
-void BufferedBlock<verts_per_face>::SetDimensions(int width, int wghost, int height, int hghost, bool construct)
+template <int verts_per_face, typename datatype>
+void BufferedBlock<verts_per_face, datatype>::SetDimensions(int width, int wghost, int height, int hghost, bool construct)
 {
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 3
+   std::cerr << "Setting dimensions for a BufferedBlock\n";
+#endif
+#endif
+
 // Call base method
    if (!construct) StenciledBlock<verts_per_face>::SetDimensions(width, wghost, height, hghost, false);
 
@@ -63,7 +172,7 @@ void BufferedBlock<verts_per_face>::SetDimensions(int width, int wghost, int hei
    ExchangePartCount(edges_per_vert, default_part_per_site);
 
 // Space for the conserved variables
-   cons_vars = Create2D<ConservedVariables>(n_shells_withghost, n_faces_withghost);
+   zone_cons = Create2D<datatype>(n_shells_withghost, n_faces_withghost);
 
 // Buffer sizes: TFACE
    buf_length[GEONBR_TFACE] = side_length - (square_fill + 1) * ghost_width;
@@ -145,7 +254,7 @@ void BufferedBlock<verts_per_face>::SetDimensions(int width, int wghost, int hei
    buf_shell_start[GEONBR_RFACE] = new int**[exch_site_count[GEONBR_RFACE]];
    buf_shell_start[GEONBR_RFACE][0] = new int*[default_part_per_site[GEONBR_RFACE]];
    for (auto part = 0; part < default_part_per_site[GEONBR_RFACE]; part++) {
-      buf_shell_start[GEONBR_RFACE][0][part] = buf_shell_tab + 1;
+      buf_shell_start[GEONBR_RFACE][0][part] = buf_shell_tab + 4;
    };
    for (auto site = 1; site < exch_site_count[GEONBR_RFACE]; site++) {
       buf_shell_start[GEONBR_RFACE][site] = buf_shell_start[GEONBR_RFACE][0];
@@ -181,7 +290,7 @@ void BufferedBlock<verts_per_face>::SetDimensions(int width, int wghost, int hei
    
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 
-// REDGE: 3/4 sites with 6/4 PPS
+// REDGE: 3/4 sites with 6(5)/4(3) PPS - some entries not used at singular corners
 // 18/16 unique maps (1:1)
    buf_face_translation[GEONBR_REDGE] = new int**[exch_site_count[GEONBR_REDGE]];
    for (auto site = 0; site < exch_site_count[GEONBR_REDGE]; site++) {
@@ -195,7 +304,7 @@ void BufferedBlock<verts_per_face>::SetDimensions(int width, int wghost, int hei
    buf_shell_start[GEONBR_REDGE] = new int**[exch_site_count[GEONBR_REDGE]];
    buf_shell_start[GEONBR_REDGE][0] = new int*[default_part_per_site[GEONBR_REDGE]];
    for (auto part = 0; part < default_part_per_site[GEONBR_REDGE]; part++) {
-      buf_shell_start[GEONBR_REDGE][0][part] = buf_shell_tab + 1;
+      buf_shell_start[GEONBR_REDGE][0][part] = buf_shell_tab + 4;
    };
    for (auto site = 1; site < exch_site_count[GEONBR_RFACE]; site++) {
       buf_shell_start[GEONBR_REDGE][site] = buf_shell_start[GEONBR_REDGE][0];
@@ -203,7 +312,7 @@ void BufferedBlock<verts_per_face>::SetDimensions(int width, int wghost, int hei
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 
-// VERTX: 6/8 sites with 12/8 PPS
+// VERTX: 6/8 sites with 12(10)/8(6) PPS - some entries not used at singular corners
 // 18/16 unique maps (1:4), storage points to REDGE
    buf_face_translation[GEONBR_VERTX] = new int**[exch_site_count[GEONBR_VERTX]];
    for (auto site = 0; site < exch_site_count[GEONBR_VERTX] / 2; site++) {
@@ -228,17 +337,26 @@ void BufferedBlock<verts_per_face>::SetDimensions(int width, int wghost, int hei
          buf_shell_start[GEONBR_VERTX][site * verts_per_face + site1] = buf_shell_start[GEONBR_VERTX][site * verts_per_face];
       };         
    };
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+// Starting shells have fixed values
+   buf_shell_tab[0] = 0;
+   buf_shell_tab[1] = ghost_height;
+   buf_shell_tab[2] = n_shells_withghost - 2 * ghost_height;
+   buf_shell_tab[3] = n_shells_withghost - ghost_height;
+   buf_shell_tab[4] = 2 * ghost_height;
 };
 
 /*!
 \author Vladimir Florinski
 \date 12/23/2024
 */
-template <int verts_per_face>
-void BufferedBlock<verts_per_face>::FreeStorage(void)
+template <int verts_per_face, typename datatype>
+void BufferedBlock<verts_per_face, datatype>::FreeStorage(void)
 {
 // Free up storage for the variables
-   Delete2D(cons_vars);
+   Delete2D(zone_cons);
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -333,45 +451,245 @@ void BufferedBlock<verts_per_face>::FreeStorage(void)
 
 /*!
 \author Vladimir Florinski
-\date 06/26/2024
+\date 01/09/2025
 \param[in] ntype         Neighbor type
 \param[in] exch_sites_in Array of pointers to exchange sites of this type
 */
-template <int verts_per_face>
-void BufferedBlock<verts_per_face>::ImportExchangeSites(NeighborType ntype, const std::vector<std::shared_ptr<ExchangeSite<ConservedVariables>>>& exch_sites_in)
+template <int verts_per_face, typename datatype>
+void BufferedBlock<verts_per_face, datatype>::ImportExchangeSites(NeighborType ntype, const std::vector<std::shared_ptr<ExchangeSite<datatype>>>& exch_sites_in)
 {
    exch_sites[ntype] = exch_sites_in;
-/*
-   exch_sites[ntype].clear();
-   for (auto site : exch_sites_in) {
-      exch_sites[ntype].emplace_back();
-      exch_sites[ntype].back() = site;
+
+// Compute the buffer translations
+   int bufidx, i_origin, j_origin, vert_origin, i0, j0, i, j, face_origin, rot, my_part, missing_part, old_part, foreign;
+   int** buf_face_translation_tmp;
+   std::pair<int, int> origin_arr[exch_site_count[GEONBR_RFACE] * default_part_per_site[GEONBR_RFACE]];
+
+   switch(ntype) {
+   
+// TFACE: 1 unique map
+   case GEONBR_TFACE:
+      rot = 0;
+      bufidx = 0;
+
+// Vertex origin for the sub-block
+      i_origin = 2 * square_fill * ghost_width;
+      j_origin = 2 * ghost_width;
+      vert_origin = vert_index_sector[i_origin][j_origin];
+
+// Face origin for the sub-block
+      face_origin = vf_local[vert_origin][3];
+      i0 = face_index_i[face_origin];
+      j0 = face_index_j[face_origin];
+
+      for (auto i_buf = 0; i_buf < buf_length[GEONBR_TFACE]; i_buf++) {
+         i = i0 + i_buf * rotated_faces[rot][0][0];
+         j = j0 + i_buf * rotated_faces[rot][1][0];
+         for (auto j_buf = 0; j_buf <= MaxFaceJ(buf_length[GEONBR_TFACE], buf_width[GEONBR_TFACE], i_buf); j_buf++) {
+            buf_face_translation[GEONBR_TFACE][0][0][bufidx++] = face_index_sector[i][j];
+            i += rotated_faces[rot][0][1 + j_buf % square_fill];
+            j += rotated_faces[rot][1][1 + j_buf % square_fill];
+         };
+      };
+      break;
+
+// RFACE/TEDGE: 6/8 unique maps
+   case GEONBR_RFACE:
+      origin_arr[0].first = total_length - (3 - square_fill) * ghost_width;
+      origin_arr[0].second = 2 * ghost_width;
+
+      origin_arr[0 + verts_per_face].first = 2 * ghost_width;
+      origin_arr[0 + verts_per_face].second = 0;
+
+      origin_arr[1].first = total_length - 2 * ghost_width;
+      origin_arr[1].second = total_length - (square_fill + 1) * ghost_width;
+
+      origin_arr[1 + verts_per_face].first = total_length;
+      origin_arr[1 + verts_per_face].second = 2 * ghost_width;
+
+      origin_arr[2].first = 2 * ghost_width;
+      origin_arr[2].second = (verts_per_face == 3 ? ghost_width : total_length - 2 * ghost_width);
+
+      origin_arr[2 + verts_per_face].first = total_length - 2 * ghost_width;
+      origin_arr[2 + verts_per_face].second = total_length - (square_fill - 1) * ghost_width;
+
+      if (verts_per_face == 4) {
+         origin_arr[3].first = 2 * ghost_width;
+         origin_arr[3].second = 2 * ghost_width;
+
+         origin_arr[3 + verts_per_face].first = 0;
+         origin_arr[3 + verts_per_face].second = total_length - 2 * ghost_width;
+      };
+
+      for (auto site = 0; site < exch_site_count[GEONBR_RFACE]; site++) {
+         my_part = exch_sites[GEONBR_RFACE][site]->PartOfLabel(block_index);
+         for (auto part = 0; part < default_part_per_site[GEONBR_RFACE]; part++) {
+            foreign = (part == my_part ? 0 : 1);
+
+// The base vertices are on the opposite sides of two sub-blocks, and "foreign" selects which side it is.
+            i_origin = origin_arr[site + foreign * verts_per_face].first;
+            j_origin = origin_arr[site + foreign * verts_per_face].second;
+            vert_origin = vert_index_sector[i_origin][j_origin];
+
+            face_origin = vf_local[vert_origin][(site * square_fill + foreign * cardinal_directions) % edges_per_vert];
+            i0 = face_index_i[face_origin];
+            j0 = face_index_j[face_origin];
+
+            rot = (corner_rotation[site] + foreign * cardinal_directions) % edges_per_vert;
+
+            bufidx = 0;
+            for (auto i_buf = 0; i_buf < buf_length[GEONBR_RFACE]; i_buf++) {
+               i = i0 + i_buf * rotated_faces[rot][0][0];
+               j = j0 + i_buf * rotated_faces[rot][1][0];
+               for(auto j_buf = 0; j_buf <= MaxFaceJ(buf_length[GEONBR_RFACE], buf_width[GEONBR_RFACE], i_buf); j_buf++) {
+                  buf_face_translation[GEONBR_RFACE][site][part][bufidx++] = face_index_sector[i][j];
+                  i += rotated_faces[rot][0][1 + j_buf % square_fill];
+                  j += rotated_faces[rot][1][1 + j_buf % square_fill];
+               };
+            };   
+         };
+      };
+      break;
+
+// REDGE/VERTX: 18(15)/16(12) unique maps
+   case GEONBR_REDGE:
+
+      origin_arr[0].first = square_fill * ghost_width;
+      origin_arr[0].second = ghost_width;
+
+      origin_arr[1].first = total_length - ghost_width;
+      origin_arr[1].second = ghost_width;
+
+      origin_arr[2].first = total_length - ghost_width;
+      origin_arr[2].second = MaxVertJ(total_length, origin_arr[2].first) - ghost_width;
+
+      if (verts_per_face == 4) {
+         origin_arr[3].first = square_fill * ghost_width;
+         origin_arr[3].second = total_length - ghost_width;
+      };
+
+      for (auto site = 0; site < exch_site_count[GEONBR_REDGE]; site++) {
+         i_origin = origin_arr[site].first;
+         j_origin = origin_arr[site].second;
+         vert_origin = vert_index_sector[i_origin][j_origin];
+
+         my_part = exch_sites[GEONBR_REDGE][site]->PartOfLabel(block_index);
+         missing_part = -1;
+
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 2
+         std::cerr << "Site " << site << " index " << exch_sites[GEONBR_REDGE][site]->GetIndex()
+                   << " my part is " << exch_sites[GEONBR_REDGE][site]->PartOfLabel(block_index) << std::endl;
+#endif
+#endif
+         
+         for (auto part = 0; part < default_part_per_site[GEONBR_REDGE]; part++) {
+            rot = (corner_rotation[site] + part + cardinal_directions - my_part) % edges_per_vert;
+            face_origin = vf_local[vert_origin][(rot + cardinal_directions) % edges_per_vert];
+
+// Missing part at a singular corner is flagged
+            if (face_origin == -1) {
+               missing_part = part;
+               continue;
+            };
+               
+            i0 = face_index_i[face_origin];
+            j0 = face_index_j[face_origin];
+
+            bufidx = 0;
+            for (auto i_buf = 0; i_buf < buf_length[GEONBR_REDGE]; i_buf++) {
+               i = i0 + i_buf * rotated_faces[rot][0][0];
+               j = j0 + i_buf * rotated_faces[rot][1][0];
+               for (auto j_buf = 0; j_buf <= MaxFaceJ(buf_length[GEONBR_REDGE], buf_width[GEONBR_REDGE], i_buf); j_buf++) {
+                  buf_face_translation[GEONBR_REDGE][site][part][bufidx++] = face_index_sector[i][j];
+                  i += rotated_faces[rot][0][1 + j_buf % square_fill];
+                  j += rotated_faces[rot][1][1 + j_buf % square_fill];
+               };
+            };   
+         };
+
+// Compress the translation arrays to remove the hole at the "missing_part". We use the fact that "my_part" is never a missing part.
+         if (missing_part != -1) {
+            buf_face_translation_tmp = new int*[default_part_per_site[GEONBR_REDGE]];
+            buf_face_translation_tmp[my_part] = buf_face_translation[GEONBR_REDGE][site][my_part];
+            buf_face_translation_tmp[default_part_per_site[GEONBR_REDGE] - 1] = buf_face_translation[GEONBR_REDGE][site][missing_part];
+
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 2
+         std::cerr << "Part " << my_part << " is mapped to " << my_part << std::endl;
+         std::cerr << "Part " << default_part_per_site[GEONBR_REDGE] - 1 << " is mapped to " << missing_part << std::endl;
+#endif
+#endif
+
+// Half loop toward decreasing "part"
+            old_part = my_part + default_part_per_site[GEONBR_REDGE];
+            for (auto part = my_part - 1; part >= 0; part--) {
+               old_part--;
+               if(part == missing_part) old_part--;
+               buf_face_translation_tmp[part] = buf_face_translation[GEONBR_REDGE][site][old_part % default_part_per_site[GEONBR_REDGE]];
+
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 2
+         std::cerr << "Part " << part << " is mapped to " << old_part % default_part_per_site[GEONBR_REDGE] << std::endl;
+#endif
+#endif
+            };
+
+// Half loop toward increasing "part"
+            old_part = my_part + default_part_per_site[GEONBR_REDGE];
+            for (auto part = my_part + 1; part < default_part_per_site[GEONBR_REDGE] - 1; part++) {
+               old_part++;
+               if(part == missing_part) old_part++;
+               buf_face_translation_tmp[part] = buf_face_translation[GEONBR_REDGE][site][old_part % default_part_per_site[GEONBR_REDGE]];
+
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 2
+         std::cerr << "Part " << part << " is mapped to " << old_part % default_part_per_site[GEONBR_REDGE] << std::endl;
+#endif
+#endif
+            };
+            
+// Replace the map
+            for (auto part = 0; part < default_part_per_site[GEONBR_REDGE]; part++) {
+               buf_face_translation[GEONBR_REDGE][site][part] = buf_face_translation_tmp[part];
+            };
+            delete[] buf_face_translation_tmp;
+         };
+
+      };
+      break;
+
+   default:
+      break;
+
    };
-*/
 };
 
 /*!
 \author Vladimir Florinski
-\date 06/27/2024
+\date 01/10/2025
 \param[in] ntype Neighbor type
 */
-template <int verts_per_face>
-void BufferedBlock<verts_per_face>::PackBuffers(NeighborType ntype) const
+template <int verts_per_face, typename datatype>
+void BufferedBlock<verts_per_face, datatype>::PackBuffers(NeighborType ntype) const
 {
    int my_part, face, starting_shell;
    size_t bufidx;
-   ConservedVariables* buffer;
+   datatype* buffer;
 
    for (auto site = 0; site < exch_site_count[ntype]; site++) {
-      my_part = exch_sites[ntype][site]->part_lookup[block_index];
-      buffer = exch_sites[ntype][site]->buffer_entry[my_part];
+      my_part = exch_sites[ntype][site]->PartOfLabel(block_index);
+
+// Find the starting position in the correct buffer
+      buffer = exch_sites[ntype][site]->BufferAddress(my_part);
       starting_shell = *buf_shell_start[ntype][site][my_part];
       bufidx = 0;
 
+// Copy each zone into the buffer
       for (auto shell = starting_shell; shell < starting_shell + buf_height[ntype]; shell++) {
          for (auto face_buf = 0; face_buf < buf_area[ntype]; face_buf++) {
             face = buf_face_translation[ntype][site][my_part][face_buf];
-            buffer[bufidx++] = cons_vars[shell][face];
+            buffer[bufidx++] = zone_cons[shell][face];
          };
       };
    };
@@ -379,36 +697,46 @@ void BufferedBlock<verts_per_face>::PackBuffers(NeighborType ntype) const
 
 /*!
 \author Vladimir Florinski
-\date 06/27/2024
+\date 01/10/2025
 \param[in] ntype Neighbor type
 */
-template <int verts_per_face>
-void BufferedBlock<verts_per_face>::UnPackBuffers(NeighborType ntype)
+template <int verts_per_face, typename datatype>
+void BufferedBlock<verts_per_face, datatype>::UnPackBuffers(NeighborType ntype)
 {
-   int my_part, face, starting_shell;
+   int my_part, face, starting_shell, actual_part;
    size_t bufidx;
-   ConservedVariables* buffer;
+   datatype* buffer;
 
    for (auto site = 0; site < exch_site_count[ntype]; site++) {
-      my_part = exch_sites[ntype][site]->part_lookup[block_index];
+      my_part = exch_sites[ntype][site]->PartOfLabel(block_index);
 
-// TODO check if this works at singular corners
-      for (auto part = 0; part < default_part_per_site[ntype]; part++) {
+      for (auto part = 0; part < exch_sites[ntype][site]->GetPartCount(); part++) {
 
-// The part equal to ours will be skipped
-         if (part == my_part) continue;
+// The part equal to ours is skipped
+         if (actual_part == my_part) {
+            actual_part++;
+            continue;
+         };
 
-         buffer = exch_sites[ntype][site]->buffer_entry[part];
+#ifdef GEO_DEBUG
+#if GEO_DEBUG_LEVEL >= 2
+         std::cerr << "Unpacking block " << block_index << " site " << site << " part " << part << " my part " << my_part << std::endl;
+#endif
+#endif
+
+// Find the starting position in the correct buffer
+         buffer = exch_sites[ntype][site]->BufferAddress(part);
          starting_shell = *buf_shell_start[ntype][site][part];
          bufidx = 0;
 
-// Copy each zone in the buffer to its proper place in the block
+// Copy each zone from the buffer
          for (auto shell = starting_shell; shell < starting_shell + buf_height[ntype]; shell++) {
             for (auto face_buf = 0; face_buf < buf_area[ntype]; face_buf++) {
                face = buf_face_translation[ntype][site][part][face_buf];
-               cons_vars[shell][face] = buffer[bufidx++];
+               zone_cons[shell][face] = buffer[bufidx++];
             };
          };
+         actual_part++;
       };
    };
 };
@@ -422,161 +750,101 @@ void BufferedBlock<verts_per_face>::UnPackBuffers(NeighborType ntype)
 \param[in] site  Site index of this type
 \param[in] part  Participant index in this site
 */
-template <int verts_per_face>
-void BufferedBlock<verts_per_face>::PrintBufferMap(NeighborType ntype, int site, int part) const
+template <int verts_per_face, typename datatype>
+void BufferedBlock<verts_per_face, datatype>::PrintBufferMap(NeighborType ntype, int site, int part) const
 {
-   for(auto face_buf = 0; face_buf < buf_area[ntype]; face_buf++) {
+   for (auto face_buf = 0; face_buf < buf_area[ntype]; face_buf++) {
       std::cerr << std::setw(6) << face_buf << std::setw(6) << buf_face_translation[ntype][site][part][face_buf] << std::endl;
+   };
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/02/2025
+*/
+template <>
+void BufferedBlock<3, int>::FillWithIndexData(void)
+{
+   for (auto shell = 0; shell < n_shells_withghost; shell++) {
+      for (auto face = 0; face < n_faces_withghost; face++) {
+
+// Assign only the internal zones (one could use shell information as well).
+         if((shell >= ghost_height) && (shell < n_shells + ghost_height) && BITS_RAISED(face_mask[face], GEOELM_INTR)) zone_cons[shell][face] = face;
+         else zone_cons[shell][face] = -1;
+      };
+   };
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/02/2025
+*/
+template <>
+void BufferedBlock<4, int>::FillWithIndexData(void)
+{
+   for (auto shell = 0; shell < n_shells_withghost; shell++) {
+      for (auto face = 0; face < n_faces_withghost; face++) {
+
+// Assign only the internal zones (one could use shell information as well).
+         if((shell >= ghost_height) && (shell < n_shells + ghost_height) && BITS_RAISED(face_mask[face], GEOELM_INTR)) zone_cons[shell][face] = face;
+         else zone_cons[shell][face] = -1;
+      };
+   };
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/10/2025
+*/
+template <>
+void BufferedBlock<3, int>::PrintContents(void)
+{
+   int face;
+   std::cout << std::endl;
+   std::cerr << "Printing the contents of block " << block_index << std::endl;
+   for (auto shell = 0; shell < n_shells_withghost; shell++) {
+      for (auto twoj = total_length - 1; twoj >= 0; twoj--) {
+         for (auto k = 0; k < total_length - twoj; k++) std::cout << "    ";
+
+         for (auto i = 0; i < total_length; i++) {
+            if(i) {
+               face = face_index_sector[i][2 * twoj + 1];
+               if(face == -1) std::cout << "    ";
+               else std::cout << std::setw(4) << zone_cons[shell][face];
+            };
+            face = face_index_sector[i][2 * twoj];
+            if(face == -1) std::cout << "    ";
+            else std::cout << std::setw(4) << zone_cons[shell][face];
+         };
+         std::cout << std::endl;
+      };
+      std::cout << std::endl;
+   };
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/10/2025
+*/
+template <>
+void BufferedBlock<4, int>::PrintContents(void)
+{
+   std::cout << std::endl;
+   std::cerr << "Printing the contents of block " << block_index << std::endl;
+   for (auto shell = 0; shell < n_shells_withghost; shell++) {
+      for (auto i = 0; i < total_length; i++) {
+         std::cout << std::endl;
+         for (auto j = 0; j <= MaxFaceJ(total_length, i); j++) {
+            std::cout << std::setw(4) << zone_cons[shell][face_index_sector[i][j]];
+         };
+      };
+      std::cout << std::endl;
    };
 };
 
 #endif
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-// BufferedBlock protected methods
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-/*!
-\author Vladimir Florinski
-\date 06/18/2024
-*/
-template <int verts_per_face>
-void BufferedBlock<verts_per_face>::ComputeBufferTranslations(void)
-{
-   int bufidx, i_origin, j_origin, vert_origin, i0, j0, i, j, face_origin, rot, my_part, foreign;
-   std::pair<int, int> origin_arr[exch_site_count[GEONBR_RFACE] * default_part_per_site[GEONBR_RFACE]];
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-// TFACE: 1 unique map
-   rot = 0;
-   bufidx = 0;
-
-// Vertex origin for the sub-block
-   i_origin = 2 * square_fill * ghost_width;
-   j_origin = 2 * ghost_width;
-   vert_origin = vert_index_sector[i_origin][j_origin];
-
-// Face origin for the sub-block
-   face_origin = vf_local[vert_origin][3];
-   i0 = face_index_i[face_origin];
-   j0 = face_index_j[face_origin];
-
-   for (auto i_buf = 0; i_buf < buf_length[GEONBR_TFACE]; i_buf++) {
-      for (auto j_buf = 0; j_buf <= MaxFaceJ(buf_length[GEONBR_TFACE], buf_width[GEONBR_TFACE], i_buf); j_buf++) {
-         i = i0 + i_buf * rotated_faces[rot][0][0] + j_buf * rotated_faces[rot][0][1 + j_buf % square_fill];
-         j = j0 + i_buf * rotated_faces[rot][1][0] + j_buf * rotated_faces[rot][1][1 + j_buf % square_fill];
-         buf_face_translation[GEONBR_TFACE][0][0][bufidx++] = face_index_sector[i][j];
-      };
-   };   
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-// RFACE/TEDGE: 6/8 unique maps
-   origin_arr[0].first = total_length - (3 - square_fill) * ghost_width;
-   origin_arr[0].second = 2 * ghost_width;
-
-   origin_arr[0 + verts_per_face].first = 2 * ghost_width;
-   origin_arr[0 + verts_per_face].second = 0;
-
-   origin_arr[1].first = total_length - 2 * ghost_width;
-   origin_arr[1].second = total_length - (square_fill + 1) * ghost_width;
-
-   origin_arr[1 + verts_per_face].first = total_length;
-   origin_arr[1 + verts_per_face].second = 2 * ghost_width;
-
-   origin_arr[2].first = 2 * ghost_width;
-   origin_arr[2].second = (verts_per_face == 3 ? ghost_width : total_length - 2 * ghost_width);
-
-   origin_arr[2 + verts_per_face].first = total_length - 2 * ghost_width;
-   origin_arr[2 + verts_per_face].second = total_length - (square_fill - 1) * ghost_width;
-
-   if (verts_per_face == 4) {
-      origin_arr[3].first = 2 * ghost_width;
-      origin_arr[3].second = 2 * ghost_width;
-
-      origin_arr[3 + verts_per_face].first = 0;
-      origin_arr[3 + verts_per_face].second = total_length - 2 * ghost_width;
-   };
-
-   for (auto site = 0; site < exch_site_count[GEONBR_RFACE]; site++) {
-      my_part = exch_sites[GEONBR_RFACE][site]->part_lookup[block_index];
-      for (auto part = 0; part < default_part_per_site[GEONBR_RFACE]; part++) {
-         foreign = (part == my_part ? 0 : 1);
-
-// The base vertices are on the opposite sides of two sub-blocks, and "foreign" selects which side it is.
-         i_origin = origin_arr[site + foreign * verts_per_face].first;
-         j_origin = origin_arr[site + foreign * verts_per_face].second;
-         vert_origin = vert_index_sector[i_origin][j_origin];
-
-         face_origin = vf_local[vert_origin][(site * square_fill + foreign * cardinal_directions) % edges_per_vert];
-         i0 = face_index_i[face_origin];
-         j0 = face_index_j[face_origin];
-
-         rot = (corner_rotation[site] + foreign * cardinal_directions) % edges_per_vert;
-
-         bufidx = 0;
-         for (auto i_buf = 0; i_buf < buf_length[GEONBR_RFACE]; i_buf++) {
-            for(auto j_buf = 0; j_buf <= MaxFaceJ(buf_length[GEONBR_RFACE], buf_width[GEONBR_RFACE], i_buf); j_buf++) {
-               i = i0 + i_buf * rotated_faces[rot][0][0] + j_buf * rotated_faces[rot][0][1 + j_buf % square_fill];
-               j = j0 + i_buf * rotated_faces[rot][1][0] + j_buf * rotated_faces[rot][1][1 + j_buf % square_fill];
-               buf_face_translation[GEONBR_RFACE][site][part][bufidx++] = face_index_sector[i][j];
-            };
-         };   
-      };
-   };
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-// REDGE/VERTX: 18/16 unique maps
-   origin_arr[0].first = square_fill * ghost_width;
-   origin_arr[0].second = ghost_width;
-
-   origin_arr[1].first = total_length - ghost_width;
-   origin_arr[1].second = ghost_width;
-
-   origin_arr[2].first = total_length - ghost_width;
-   origin_arr[2].second = total_length - ghost_width;
-
-   if (verts_per_face == 4) {
-      origin_arr[3].first = square_fill * ghost_width;
-      origin_arr[3].second = total_length - ghost_width;
-   };
-
-   for (auto site = 0; site < exch_site_count[GEONBR_REDGE]; site++) {
-      i_origin = origin_arr[site].first;
-      j_origin = origin_arr[site].second;
-      vert_origin = vert_index_sector[i_origin][j_origin];
-
-      my_part = exch_sites[GEONBR_REDGE][site]->part_lookup[block_index];
-      for (auto part = 0; part < default_part_per_site[GEONBR_REDGE]; part++) {
-         face_origin = vf_local[vert_origin][(part + 3 * cardinal_directions - my_part) % edges_per_vert];
-         i0 = face_index_i[face_origin];
-         j0 = face_index_j[face_origin];
-
-         rot = (part + edges_per_vert - my_part) % edges_per_vert;
-
-         bufidx = 0;
-         for (auto i_buf = 0; i_buf < buf_length[GEONBR_REDGE]; i_buf++) {
-            for(auto j_buf = 0; j_buf <= MaxFaceJ(buf_length[GEONBR_REDGE], buf_width[GEONBR_REDGE], i_buf); j_buf++) {
-               i = i0 + i_buf * rotated_faces[rot][0][0] + j_buf * rotated_faces[rot][0][1 + j_buf % square_fill];
-               j = j0 + i_buf * rotated_faces[rot][1][0] + j_buf * rotated_faces[rot][1][1 + j_buf % square_fill];
-               buf_face_translation[GEONBR_REDGE][site][part][bufidx++] = face_index_sector[i][j];
-            };
-         };   
-      };
-   };
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Starting shells
-   buf_shell_tab[0] = 0;
-   buf_shell_tab[1] = ghost_height;
-   buf_shell_tab[2] = n_shells_withghost - 2 * ghost_height;
-   buf_shell_tab[3] = n_shells_withghost - ghost_height;
-};
-
-template class BufferedBlock<3>;
-template class BufferedBlock<4>;
+template class BufferedBlock<3, int>;
+//template class BufferedBlock<4, int>;
 
 };

--- a/geodesic/buffered_block.hh
+++ b/geodesic/buffered_block.hh
@@ -9,10 +9,8 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 #ifndef SPECTRUM_BUFFERED_BLOCK_HH
 #define SPECTRUM_BUFFERED_BLOCK_HH
 
-#include "geodesic/stenciled_block.hh"
-#include "fluid/variables.hh"
 #include "common/exchange_site.hh"
-#include "common/mpi_config.hh"
+#include "geodesic/stenciled_block.hh"
 
 namespace Spectrum {
 
@@ -66,7 +64,7 @@ inline void ExchangePartCount(int q, int* part_count)
 
 Extends the StencilBlock class with (a) storage for conserved variables and (b) buffers for variable exchange between neighboring blocks
 */
-template <int verts_per_face>
+template <int verts_per_face, typename datatype>
 class BufferedBlock : public StenciledBlock<verts_per_face>
 {
 protected:
@@ -88,9 +86,11 @@ protected:
    using GeodesicSector<verts_per_face>::face_index_i;
    using GeodesicSector<verts_per_face>::face_index_j;
    using GeodesicSector<verts_per_face>::vf_local;
+   using GeodesicSector<verts_per_face>::MaxVertJ;
    using GridBlock<verts_per_face>::block_index;
    using GridBlock<verts_per_face>::corner_rotation;
    using GridBlock<verts_per_face>::rotated_faces;
+   using StenciledBlock<verts_per_face>::MaxFaceJ;
 
 //! Number of exchange sites
    int exch_site_count[N_NBRTYPES];
@@ -99,7 +99,7 @@ protected:
    int default_part_per_site[N_NBRTYPES];
 
 //! Pointers of exchange sites
-   std::vector<std::shared_ptr<ExchangeSite<ConservedVariables>>> exch_sites[N_NBRTYPES];
+   std::vector<std::shared_ptr<ExchangeSite<datatype>>> exch_sites[N_NBRTYPES];
 
 //! Buffer side length
    int buf_length[N_NBRTYPES];
@@ -117,33 +117,27 @@ protected:
    int buf_volume[N_NBRTYPES];
 
 //! Conserved variables storage
-   ConservedVariables** cons_vars = nullptr;
+   datatype** zone_cons = nullptr;
 
 //! Translation tables for each buffer (site, part, face)
    int*** buf_face_translation[N_NBRTYPES] = {nullptr};
 
 //! Starting shell table
-   int buf_shell_tab[4];
+   int buf_shell_tab[5];
 
 //! Starting shell indices for each buffer (site, part), accessed through a pointer
    int*** buf_shell_start[N_NBRTYPES] = {nullptr};
 
-//! Maximum value of the vertex j-index for the given vertex i-index for a truncated block
-   SPECTRUM_DEVICE_FUNC int MaxVertJ(int len, int height, int i) const;
-
-//! Maximum value of the face j-index for the given face i-index for a truncated block
-   SPECTRUM_DEVICE_FUNC int MaxFaceJ(int len, int height, int i) const;
-
-//! Generate address maps for the buffers
-   void ComputeBufferTranslations(void);
-
 public:
 
 //! Default constructor
-   BufferedBlock(void) = default;
+   BufferedBlock(void);
 
 //! Copy constructor
    BufferedBlock(const BufferedBlock& other);
+
+//! Move constructor
+   BufferedBlock(BufferedBlock&& other);
 
 //! Constructor with arguments
    BufferedBlock(int width, int wghost, int height, int hghost);
@@ -157,10 +151,16 @@ public:
 //! Free all dynamically allocated memory
    void FreeStorage(void);
 
-//! Assign exchange site objects
-   void ImportExchangeSites(NeighborType ntype, const std::vector<std::shared_ptr<ExchangeSite<ConservedVariables>>>& exch_sites_in);
+//! Assign exchange site objects and generate address maps for the buffers
+   void ImportExchangeSites(NeighborType ntype, const std::vector<std::shared_ptr<ExchangeSite<datatype>>>& exch_sites_in);
 
-//! Return the size of the buffer (in units of ConservedVariables)
+//! Return the number of exchange sites
+   int GetExchangeSiteCount(NeighborType ntype) const {return exch_site_count[ntype];};
+
+//! Return the number of exchange sites
+   int GetPartCount(NeighborType ntype) const {return default_part_per_site[ntype];};
+
+//! Return the size of the buffer (in units of datatype)
    int GetBufferSize(NeighborType ntype) const {return buf_volume[ntype];};
 
 //! Pack ghost regions for exchange
@@ -170,66 +170,18 @@ public:
    void UnPackBuffers(NeighborType ntype);
 
 #ifdef GEO_DEBUG
+
 //! Print a buffer map
    void PrintBufferMap(NeighborType ntype, int site, int part) const;
+
+//! Fill the data with index values
+   void FillWithIndexData(void);
+
+//! Print the contents of the entire block
+   void PrintContents(void);
+
 #endif
 
-};
-
-/*!
-\author Vladimir Florinski
-\date 06/14/2024
-\param[in] len    Side length
-\param[in] height Height of the block in _vertices_
-\param[in] i      i-index
-\return Largest j-index for this i
-*/
-template <>
-SPECTRUM_DEVICE_FUNC inline int BufferedBlock<3>::MaxVertJ(int len, int height, int i) const
-{
-   return std::min(i, height);
-};
-
-/*!
-\author Vladimir Florinski
-\date 06/14/2024
-\param[in] len    Side length
-\param[in] height Height of the block in _vertices_
-\param[in] i      i-index
-\return Largest j-index for this i
-*/
-template <>
-SPECTRUM_DEVICE_FUNC inline int BufferedBlock<4>::MaxVertJ(int len, int height, int i) const
-{
-   return height;
-};
-
-/*!
-\author Vladimir Florinski
-\date 06/14/2024
-\param[in] len    Side length
-\param[in] height Height of the block in _vertices_
-\param[in] i      i-index
-\return Largest j-index for this i
-*/
-template <>
-SPECTRUM_DEVICE_FUNC inline int BufferedBlock<3>::MaxFaceJ(int len, int height, int i) const
-{
-   return (i < height ? square_fill * i : square_fill * height - 1);
-};
-
-/*!
-\author Vladimir Florinski
-\date 06/14/2024
-\param[in] len    Side length
-\param[in] height Height of the block in _vertices_
-\param[in] i      i-index
-\return Largest j-index for this i
-*/
-template <>
-SPECTRUM_DEVICE_FUNC inline int BufferedBlock<4>::MaxFaceJ(int len, int height, int i) const
-{
-   return height - 1;
 };
 
 };

--- a/geodesic/domain_partition.hh
+++ b/geodesic/domain_partition.hh
@@ -190,6 +190,9 @@ public:
 //! Constructor with arguments
    DomainPartition(int n_shells, const std::shared_ptr<DistanceBase> dist_map, double face_div);
 
+//! Copy constructor - deleted because only a single partition can exist
+   DomainPartition(const DomainPartition& other) = delete;
+
 //! Destructor
    ~DomainPartition();
 
@@ -234,7 +237,7 @@ inline int DomainPartition<datatype, blocktype>::GetSlab(int bidx) const
 template <typename datatype, typename blocktype>
 inline int DomainPartition<datatype, blocktype>::GetSector(int bidx) const
 {
-   return bidx % n_slabs;
+   return bidx % n_sectors;
 };
 
 };

--- a/geodesic/geodesic_sector.hh
+++ b/geodesic/geodesic_sector.hh
@@ -6,10 +6,11 @@
 This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
 */
 
-#ifndef SPECTRUM_GEODESIC_SECTOR
-#define SPECTRUM_GEODESIC_SECTOR
+#ifndef SPECTRUM_GEODESIC_SECTOR_HH
+#define SPECTRUM_GEODESIC_SECTOR_HH
 
 #include <cstdint>
+
 #include "geodesic/polygonal_addressing.hh"
 
 namespace Spectrum {
@@ -249,10 +250,13 @@ protected:
 public:
 
 //! Default constructor
-   SPECTRUM_DEVICE_FUNC GeodesicSector(void) = default;
+   SPECTRUM_DEVICE_FUNC GeodesicSector(void);
 
 //! Copy constructor
    SPECTRUM_DEVICE_FUNC GeodesicSector(const GeodesicSector& other);
+
+//! Move constructor
+   SPECTRUM_DEVICE_FUNC GeodesicSector(GeodesicSector&& other);
 
 //! Constructor with arguments
    SPECTRUM_DEVICE_FUNC GeodesicSector(int width, int wghost);

--- a/geodesic/polygonal_addressing.hh
+++ b/geodesic/polygonal_addressing.hh
@@ -29,7 +29,7 @@ static constexpr int EdgesAtVert(void)
 \brief A class describing the Triangular Addressing Scheme (TAS) and Quad Addressing Scheme (QAS)
 \author Vladimir Florinski
 
-This class's role is to fill out the bootstrap arrays ("vert_vert", "vert_ende", etc.) that are used later in the "GeodesicSector" class to generate the connectivity arrays ("vv_local", "ve_local", etc.) The bootstrap arrays have minimum utility beyond that, and it is recommended that they are not used in classes derived from "GeodesicSector".
+This class's role is to fill in the bootstrap arrays ("vert_vert", "vert_edge", etc.) that are used later in the "GeodesicSector" class to generate the connectivity arrays ("vv_local", "ve_local", etc.) The bootstrap arrays have minimum utility beyond that, and it is recommended that they are not used in classes derived from "GeodesicSector".
 */
 template <int verts_per_face>
 class PolygonalAddressing
@@ -96,6 +96,9 @@ public:
 
 //! Copy constructor
    SPECTRUM_DEVICE_FUNC PolygonalAddressing(const PolygonalAddressing<verts_per_face>& other);
+
+//! Move constructor
+   SPECTRUM_DEVICE_FUNC PolygonalAddressing(PolygonalAddressing<verts_per_face>&& other);
 };
 
 /*!
@@ -115,6 +118,17 @@ SPECTRUM_DEVICE_FUNC inline PolygonalAddressing<verts_per_face>::PolygonalAddres
 */
 template <int verts_per_face>
 SPECTRUM_DEVICE_FUNC inline PolygonalAddressing<verts_per_face>::PolygonalAddressing(const PolygonalAddressing<verts_per_face>& other)
+                                                               : PolygonalAddressing<verts_per_face>()
+{
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/08/20256
+\param[in] other Object to move into this
+*/
+template <int verts_per_face>
+SPECTRUM_DEVICE_FUNC inline PolygonalAddressing<verts_per_face>::PolygonalAddressing(PolygonalAddressing<verts_per_face>&& other)
                                                                : PolygonalAddressing<verts_per_face>()
 {
 };
@@ -162,7 +176,7 @@ SPECTRUM_DEVICE_FUNC inline int PolygonalAddressing<verts_per_face>::VertCount(i
 template <>
 SPECTRUM_DEVICE_FUNC inline constexpr void PolygonalAddressing<3>::Setup(void)
 {
-// Indexing scheme: vertex "V" and edges "T0", "T1", and "T2" have the same i and j coordinates. Face "F" (unshaded) has coordinates (i,2j). Face "S" (shaded) has coordinates (i,2j+1). When obtaining edge and vertex coorindates from face coordinates, divide the second coordinate by two, so both "F" and "S" will point to (i,j).
+// Indexing scheme: vertex "V" and edges "T0", "T1", and "T2" have the same i and j coordinates. Face "F" (upward) has coordinates (i,2j). Face "S" (downward) has coordinates (i,2j+1). When obtaining edge and vertex coorindates from face coordinates, divide the second coordinate by two, so both "F" and "S" will point to (i,j).
 
 /*          -----------
 //           \       / \
@@ -248,7 +262,7 @@ SPECTRUM_DEVICE_FUNC inline constexpr void PolygonalAddressing<3>::Setup(void)
 //                                                                                   \ /          /       \ /       \
 //                                                                                    -          ---------------------
 */
-// Unshaded faces are element [0] and shaded faces are element [1]. The correct set is chosen based on (j % 2).
+// Upward faces are element [0] and downward faces are element [1]. The correct set is chosen based on (j % 2).
 
    face_vert[0][0][0] =  0; face_vert[0][0][1] =  0;
    face_vert[0][1][0] =  1; face_vert[0][1][1] =  0;

--- a/geodesic/spherical_slab.hh
+++ b/geodesic/spherical_slab.hh
@@ -37,7 +37,7 @@ class SphericalSlab
 protected:
 
 //! Number of interior r-shells
-   int n_shells;
+   int n_shells = -1;
 
 //! Total number of r-shells, including ghost
    int n_shells_withghost;
@@ -65,6 +65,9 @@ public:
 //! Copy constructor
    SPECTRUM_DEVICE_FUNC SphericalSlab(const SphericalSlab& other);
 
+//! Move constructor
+   SPECTRUM_DEVICE_FUNC SphericalSlab(SphericalSlab&& other);
+
 //! Construtor with parameters
    SPECTRUM_DEVICE_FUNC SphericalSlab(int height, int hghost);
 
@@ -80,12 +83,25 @@ public:
 
 /*!
 \author Vladimir Florinski
-\date 06/21/2024
+\date 01/08/2025
 \param[in] other Object to initialize from
 */
 SPECTRUM_DEVICE_FUNC inline SphericalSlab::SphericalSlab(const SphericalSlab& other)
 {
+   if(other.n_shells != -1) SetDimensions(other.n_shells, other.ghost_height, true);
+};
+
+/*!
+\author Vladimir Florinski
+\date 01/08/2025
+\param[in] other Object to move into this
+*/
+SPECTRUM_DEVICE_FUNC inline SphericalSlab::SphericalSlab(SphericalSlab&& other)
+{
+   if(other.n_shells == -1) return;
+
    SetDimensions(other.n_shells, other.ghost_height, true);
+   other.n_shells = -1;
 };
 
 /*!
@@ -127,7 +143,7 @@ SPECTRUM_DEVICE_FUNC inline bool SphericalSlab::IsInteriorShellOfSlab(int k) con
 \author Vladimir Florinski
 \date 02/19/2020
 \param[in] width     Height of the slab, without ghost cells
-\param[in] wgohst    Height of the ghost cell layer outside the slab
+\param[in] hghost    Height of the ghost cell layer outside the slab
 \param[in] construct Set to true when called from a constructor
 */
 SPECTRUM_DEVICE_FUNC inline void SphericalSlab::SetDimensions(int height, int hghost, bool construct)

--- a/geodesic/stenciled_block.hh
+++ b/geodesic/stenciled_block.hh
@@ -10,13 +10,10 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 #define SPECTRUM_STENCILED_BLOCK_HH
 
 #include <eigen3/Eigen/Dense>
+
 #include "geodesic/grid_block.hh"
-#include "common/polynomial.hh"
 
 namespace Spectrum {
-
-//! Power law for WENO weighting
-constexpr double weno_pow = 4.0;
 
 //! Stencil element (F)
 #define GEOELM_STEN 0x0020
@@ -56,13 +53,13 @@ protected:
    using GridBlock<verts_per_face>::block_vert_cart;
 
 //! A local Polynomial object
-   Polynomial poly;
+//   Polynomial poly;
 
 //! The total number of stencils
    static constexpr int n_stencils = 1 + 2 * verts_per_face;
 
 //! Number of stenciled faces
-   int n_faces_stenciled;
+//   int n_faces_stenciled;
 
 //! Number of zones in each stencil, _excluding_ the principal
    int zones_per_stencil[n_stencils];
@@ -70,11 +67,14 @@ protected:
 //! Face areas on the US
    double* face_area = nullptr;
 
-//! Centers of mass for the US, but does _not_ lie on the US
+//! Face centers of mass for the US (do _not_ lie on the US)
    GeoVector* face_cmass = nullptr;
 
 //! Edge lengths on the US
    double* edge_length = nullptr;
+
+//! Edge centers of mass for the US (do _not_ lie on the US)
+   GeoVector* edge_cmass = nullptr;
 
 //! Stencil zonelists
    int*** stencil_zonelist = nullptr;
@@ -88,11 +88,17 @@ protected:
 //! Build a list of stenciled zones and compute the stencil mask
    void MarkStenciledArea(void);
 
+//! Maximum value of the vertex j-index for the given vertex i-index for a truncated block
+   int MaxVertJ(int len, int height, int i) const;
+
+//! Maximum value of the face j-index for the given face i-index for a truncated block
+   int MaxFaceJ(int len, int height, int i) const;
+
 //! Determine whether a zone is in the block's interior - ijk version
-   bool IsInteriorZoneOfBlock(int i, int j, int k) const;
+//   bool IsInteriorZoneOfBlock(int i, int j, int k) const;
 
 //! Determine whether a zone is in the block's interior - face+k version
-   bool IsInteriorZoneOfBlock(int face, int k) const;
+//   bool IsInteriorZoneOfBlock(int face, int k) const;
 
 //! Compute the geometry matrix for one stencil of a single face
    void ComputeOneMatrix(int pface, int stencil);
@@ -106,10 +112,13 @@ protected:
 public:
 
 //! Default constructor
-   StenciledBlock(void) = default;
+   StenciledBlock(void);
 
 //! Copy constructor
-   SPECTRUM_DEVICE_FUNC StenciledBlock(const StenciledBlock& other);
+   StenciledBlock(const StenciledBlock& other);
+
+//! Move constructor
+   StenciledBlock(StenciledBlock&& other);
 
 //! Constructor with arguments
    StenciledBlock(int width, int wghost, int height, int hghost);
@@ -125,7 +134,7 @@ public:
 
 //! Set up the dimensions and geometry of the mesh
    void AssociateMesh(double ximin, double ximax, const bool* corners, const bool* borders,
-                      const GeoVector* vcart, std::shared_ptr<DistanceBase> dist_map_in);
+                      const GeoVector* vcart, std::shared_ptr<DistanceBase> dist_map_in, bool construct);
 
 #ifdef GEO_DEBUG
 
@@ -133,10 +142,65 @@ public:
    void PrintStencilProps(int pface, int stencil) const;
 
 //! Draw stencils for a given shell and face
-   void DrawStencil(int k, int pface, int stencil, double rot_z, double rot_x) const;
+   void DrawStencil(int pshell, int pface, int stencil, double rot_z, double rot_x) const;
 
 #endif
 
+};
+/*!
+\author Vladimir Florinski
+\date 06/14/2024
+\param[in] len    Side length
+\param[in] height Height of the block in _vertices_
+\param[in] i      i-index
+\return Largest j-index for this i
+*/
+template <>
+inline int StenciledBlock<3>::MaxVertJ(int len, int height, int i) const
+{
+   return std::min(i, height);
+};
+
+/*!
+\author Vladimir Florinski
+\date 06/14/2024
+\param[in] len    Side length
+\param[in] height Height of the block in _vertices_
+\param[in] i      i-index
+\return Largest j-index for this i
+*/
+template <>
+inline int StenciledBlock<4>::MaxVertJ(int len, int height, int i) const
+{
+   return height;
+};
+
+/*!
+\author Vladimir Florinski
+\date 06/14/2024
+\param[in] len    Side length
+\param[in] height Height of the block in _vertices_
+\param[in] i      i-index
+\return Largest j-index for this i
+*/
+template <>
+inline int StenciledBlock<3>::MaxFaceJ(int len, int height, int i) const
+{
+   return (i < height ? square_fill * i : square_fill * height - 1);
+};
+
+/*!
+\author Vladimir Florinski
+\date 06/14/2024
+\param[in] len    Side length
+\param[in] height Height of the block in _vertices_
+\param[in] i      i-index
+\return Largest j-index for this i
+*/
+template <>
+inline int StenciledBlock<4>::MaxFaceJ(int len, int height, int i) const
+{
+   return height - 1;
 };
 
 /*!
@@ -147,12 +211,13 @@ public:
 \param[in] k The r-shell index
 \return True if the zone is interior to the block
 */
+/*
 template <int verts_per_face>
-SPECTRUM_DEVICE_FUNC inline bool StenciledBlock<verts_per_face>::IsInteriorZoneOfBlock(int i, int j, int k) const
+inline bool StenciledBlock<verts_per_face>::IsInteriorZoneOfBlock(int i, int j, int k) const
 {
    return SphericalSlab::IsInteriorShellOfSlab(k) && GeodesicSector<verts_per_face>::IsInteriorFaceOfSector(i, j);
 };
-
+*/
 /*!
 \author Vladimir Florinski
 \date 05/08/2024
@@ -160,12 +225,13 @@ SPECTRUM_DEVICE_FUNC inline bool StenciledBlock<verts_per_face>::IsInteriorZoneO
 \param[in] k    The r-shell index
 \return True if the zone is interior to the block
 */
+/*
 template <int verts_per_face>
-SPECTRUM_DEVICE_FUNC inline bool StenciledBlock<verts_per_face>::IsInteriorZoneOfBlock(int face, int k) const
+inline bool StenciledBlock<verts_per_face>::IsInteriorZoneOfBlock(int face, int k) const
 {
    return SphericalSlab::IsInteriorShellOfSlab(k) && GridBlock<verts_per_face>::IsInteriorFaceOfSector(face);
 };
-
+*/
 };
 
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,15 +1,769 @@
 ## Process this file with automake to produce Makefile.in
 
-AM_CXXFLAGS = $(MPI_CFLAGS)
+AM_CXXFLAGS = $(MPI_CFLAGS) -DGEO_DEBUG
+#AM_CXXFLAGS = $(MPI_CFLAGS)
 AM_LDFLAGS = $(MPI_LIBS)
+BATL_HOME = /home/vladimir/Science/Global3D/Michigan/BATL-master
 
-bin_PROGRAMS = main_test_units
+AM_FCFLAGS = -J$(BATL_HOME)/share/include
+
+bin_PROGRAMS = main_test_trajectory1 \
+               main_test_trajectory_mswave \
+               main_test_simulation1 \
+               main_test_simulation2 \
+               main_test_mpi_config \
+               main_test_units \
+               main_plot_backgrounds \
+               main_test_background_bochum \
+               main_test_background_waves \
+               main_test_background_mswave \
+               main_test_background_batl \
+               main_plot_solarwind_batl \
+               main_tesstest \
+               main_simulation_lee \
+               main_testread \
+               main_test_trajectory_batl \
+               main_test_alfven_turb \
+               main_tesstest \
+               main_drawsector \
+               main_test_exchange_site \
+               main_test_shared_site \
+               main_test_grid_block \
+               main_test_buffered_block
 
 SPBL_COMMON_DIR = ../common
 SPBL_SOURCE_DIR = ../src
+SPBL_GEODESIC_DIR = ../geodesic
+SPBL_FLUID_DIR = ../fluid
+SPBL_GEOMETRY_DIR = ../geometry
+
+main_test_trajectory1_SOURCES = main_test_trajectory1.cc \
+   $(SPBL_SOURCE_DIR)/distribution_base.cc \
+   $(SPBL_SOURCE_DIR)/distribution_base.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding_scatt.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding_scatt.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_base.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_base.hh \
+   $(SPBL_SOURCE_DIR)/background_uniform.cc \
+   $(SPBL_SOURCE_DIR)/background_uniform.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.hh \
+   $(SPBL_SOURCE_DIR)/boundary_base.cc \
+   $(SPBL_SOURCE_DIR)/boundary_base.hh \
+   $(SPBL_SOURCE_DIR)/initial_space.cc \
+   $(SPBL_SOURCE_DIR)/initial_space.hh \
+   $(SPBL_SOURCE_DIR)/initial_momentum.cc \
+   $(SPBL_SOURCE_DIR)/initial_momentum.hh \
+   $(SPBL_SOURCE_DIR)/initial_base.cc \
+   $(SPBL_SOURCE_DIR)/initial_base.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_other.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_other.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_base.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.hh \
+   $(SPBL_SOURCE_DIR)/traj_config.hh \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/rk_config.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_trajectory1_LDADD = $(MPI_LIBS) $(GSL_LIBS)
+
+main_test_trajectory_mswave_SOURCES = main_test_trajectory_mswave.cc \
+   $(SPBL_SOURCE_DIR)/distribution_base.cc \
+   $(SPBL_SOURCE_DIR)/distribution_base.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_lorentz.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_lorentz.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_base.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_base.hh \
+   $(SPBL_SOURCE_DIR)/background_mswave.cc \
+   $(SPBL_SOURCE_DIR)/background_mswave.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.hh \
+   $(SPBL_SOURCE_DIR)/boundary_time.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.hh \
+   $(SPBL_SOURCE_DIR)/boundary_base.cc \
+   $(SPBL_SOURCE_DIR)/boundary_base.hh \
+   $(SPBL_SOURCE_DIR)/initial_space.cc \
+   $(SPBL_SOURCE_DIR)/initial_space.hh \
+   $(SPBL_SOURCE_DIR)/initial_momentum.cc \
+   $(SPBL_SOURCE_DIR)/initial_momentum.hh \
+   $(SPBL_SOURCE_DIR)/initial_base.cc \
+   $(SPBL_SOURCE_DIR)/initial_base.hh \
+   $(SPBL_SOURCE_DIR)/traj_config.hh \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/rk_config.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_trajectory_mswave_LDADD = $(GSL_LIBS)
+
+main_test_simulation1_SOURCES = main_test_simulation1.cc \
+   $(SPBL_SOURCE_DIR)/simulation.cc \
+   $(SPBL_SOURCE_DIR)/simulation.hh \
+   $(SPBL_SOURCE_DIR)/distribution_other.cc \
+   $(SPBL_SOURCE_DIR)/distribution_other.hh \
+   $(SPBL_SOURCE_DIR)/distribution_base.cc \
+   $(SPBL_SOURCE_DIR)/distribution_base.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding_scatt.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding_scatt.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_base.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_base.hh \
+   $(SPBL_SOURCE_DIR)/background_uniform.cc \
+   $(SPBL_SOURCE_DIR)/background_uniform.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.hh \
+   $(SPBL_SOURCE_DIR)/boundary_space.cc \
+   $(SPBL_SOURCE_DIR)/boundary_space.hh \
+   $(SPBL_SOURCE_DIR)/boundary_base.cc \
+   $(SPBL_SOURCE_DIR)/boundary_base.hh \
+   $(SPBL_SOURCE_DIR)/initial_space.cc \
+   $(SPBL_SOURCE_DIR)/initial_space.hh \
+   $(SPBL_SOURCE_DIR)/initial_momentum.cc \
+   $(SPBL_SOURCE_DIR)/initial_momentum.hh \
+   $(SPBL_SOURCE_DIR)/initial_base.cc \
+   $(SPBL_SOURCE_DIR)/initial_base.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_other.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_other.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_base.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.hh \
+   $(SPBL_SOURCE_DIR)/traj_config.hh \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/rk_config.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_simulation1_LDADD = $(MPI_LIBS) $(GSL_LIBS)
+
+main_test_simulation2_SOURCES = main_test_simulation2.cc \
+   $(SPBL_SOURCE_DIR)/simulation.cc \
+   $(SPBL_SOURCE_DIR)/simulation.hh \
+   $(SPBL_SOURCE_DIR)/distribution_other.cc \
+   $(SPBL_SOURCE_DIR)/distribution_other.hh \
+   $(SPBL_SOURCE_DIR)/distribution_templated.cc \
+   $(SPBL_SOURCE_DIR)/distribution_templated.hh \
+   $(SPBL_SOURCE_DIR)/distribution_base.cc \
+   $(SPBL_SOURCE_DIR)/distribution_base.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding_diff_scatt.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding_diff_scatt.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding_diff.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding_diff.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_base.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_base.hh \
+   $(SPBL_SOURCE_DIR)/background_uniform.cc \
+   $(SPBL_SOURCE_DIR)/background_uniform.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.hh \
+   $(SPBL_SOURCE_DIR)/boundary_space.cc \
+   $(SPBL_SOURCE_DIR)/boundary_space.hh \
+   $(SPBL_SOURCE_DIR)/boundary_base.cc \
+   $(SPBL_SOURCE_DIR)/boundary_base.hh \
+   $(SPBL_SOURCE_DIR)/initial_space.cc \
+   $(SPBL_SOURCE_DIR)/initial_space.hh \
+   $(SPBL_SOURCE_DIR)/initial_momentum.cc \
+   $(SPBL_SOURCE_DIR)/initial_momentum.hh \
+   $(SPBL_SOURCE_DIR)/initial_base.cc \
+   $(SPBL_SOURCE_DIR)/initial_base.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_other.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_other.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_base.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.hh \
+   $(SPBL_SOURCE_DIR)/traj_config.hh \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/rk_config.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_simulation2_LDADD = $(MPI_LIBS) $(GSL_LIBS)
+
+main_test_mpi_config_SOURCES = main_test_mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh
+
+main_test_mpi_config_LDADD = $(MPI_LIBS)
 
 main_test_units_SOURCES = main_test_units.cc \
+   $(SPBL_COMMON_DIR)/physics.cc \
    $(SPBL_COMMON_DIR)/physics.hh \
-   $(SPBL_COMMON_DIR)/physics.cc
+   $(SPBL_COMMON_DIR)/definitions.hh
 
-main_test_units_LDADD = $(MPI_LIBS) $(GSL_LIBS)
+main_plot_backgrounds_SOURCES = main_plot_backgrounds.cc \
+   $(SPBL_SOURCE_DIR)/background_vlism_bochum.cc \
+   $(SPBL_SOURCE_DIR)/background_vlism_bochum.hh \
+   $(SPBL_SOURCE_DIR)/background_dipole.cc \
+   $(SPBL_SOURCE_DIR)/background_dipole.hh \
+   $(SPBL_SOURCE_DIR)/background_cylindrical_obstacle.cc \
+   $(SPBL_SOURCE_DIR)/background_cylindrical_obstacle.hh \
+   $(SPBL_SOURCE_DIR)/background_magnetized_cylinder.cc \
+   $(SPBL_SOURCE_DIR)/background_magnetized_cylinder.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/multi_index.cc \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.cc \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_plot_backgrounds_LDADD = $(GSL_LIBS)
+
+main_test_background_bochum_SOURCES = main_test_background_bochum.cc \
+   $(SPBL_SOURCE_DIR)/background_vlism_bochum.cc \
+   $(SPBL_SOURCE_DIR)/background_vlism_bochum.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_background_bochum_LDADD = $(GSL_LIBS)
+
+main_test_background_batl_SOURCES = main_test_background_batl.cc \
+   $(SPBL_SOURCE_DIR)/background_batl.cc \
+   $(SPBL_SOURCE_DIR)/background_batl.hh \
+   $(SPBL_SOURCE_DIR)/background_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/background_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/server_batl.cc \
+   $(SPBL_SOURCE_DIR)/server_batl.hh \
+   $(SPBL_SOURCE_DIR)/server_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/server_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/server_base.cc \
+   $(SPBL_SOURCE_DIR)/server_base.hh \
+   $(SPBL_SOURCE_DIR)/cache_lru.cc \
+   $(SPBL_SOURCE_DIR)/cache_lru.hh \
+   $(SPBL_SOURCE_DIR)/block_batl.cc \
+   $(SPBL_SOURCE_DIR)/block_batl.hh \
+   $(SPBL_SOURCE_DIR)/block_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/block_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/block_base.cc \
+   $(SPBL_SOURCE_DIR)/block_base.hh \
+   $(SPBL_SOURCE_DIR)/reader_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/reader_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/spectrum_interface.f90 \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/spatial_data.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_background_batl_LDADD = -L$(BATL_HOME)/lib -lREADAMR -lTIMING -lSHARE -lgfortran -lmpi_mpifh
+
+main_plot_solarwind_batl_SOURCES = main_plot_solarwind_batl.cc \
+   $(SPBL_SOURCE_DIR)/background_batl.cc \
+   $(SPBL_SOURCE_DIR)/background_batl.hh \
+   $(SPBL_SOURCE_DIR)/background_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/background_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/background_server.cc \
+   $(SPBL_SOURCE_DIR)/background_server.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/server_batl.cc \
+   $(SPBL_SOURCE_DIR)/server_batl.hh \
+   $(SPBL_SOURCE_DIR)/server_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/server_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/server_base.cc \
+   $(SPBL_SOURCE_DIR)/server_base.hh \
+   $(SPBL_SOURCE_DIR)/cache_lru.cc \
+   $(SPBL_SOURCE_DIR)/cache_lru.hh \
+   $(SPBL_SOURCE_DIR)/block_batl.cc \
+   $(SPBL_SOURCE_DIR)/block_batl.hh \
+   $(SPBL_SOURCE_DIR)/block_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/block_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/block_base.cc \
+   $(SPBL_SOURCE_DIR)/block_base.hh \
+   $(SPBL_SOURCE_DIR)/reader_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/reader_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/spectrum_interface.f90 \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/spatial_data.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_plot_solarwind_batl_LDADD = -L$(BATL_HOME)/lib -lREADAMR -lTIMING -lSHARE -lgfortran -lmpi_mpifh
+
+main_test_trajectory_batl_SOURCES = main_test_trajectory_batl.cc \
+   $(SPBL_SOURCE_DIR)/distribution_templated.cc \
+   $(SPBL_SOURCE_DIR)/distribution_templated.hh \
+   $(SPBL_SOURCE_DIR)/distribution_base.cc \
+   $(SPBL_SOURCE_DIR)/distribution_base.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_lorentz.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_lorentz.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_guiding.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_fieldline.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_fieldline.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_base.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_base.hh \
+   $(SPBL_SOURCE_DIR)/background_uniform.cc \
+   $(SPBL_SOURCE_DIR)/background_uniform.hh \
+   $(SPBL_SOURCE_DIR)/background_batl.cc \
+   $(SPBL_SOURCE_DIR)/background_batl.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/server_base.cc \
+   $(SPBL_SOURCE_DIR)/server_base.hh \
+   $(SPBL_SOURCE_DIR)/server_batl.cc \
+   $(SPBL_SOURCE_DIR)/server_batl.hh \
+   $(SPBL_SOURCE_DIR)/cache_lru.cc \
+   $(SPBL_SOURCE_DIR)/cache_lru.hh \
+   $(SPBL_SOURCE_DIR)/block_base.cc \
+   $(SPBL_SOURCE_DIR)/block_base.hh \
+   $(SPBL_SOURCE_DIR)/block_batl.cc \
+   $(SPBL_SOURCE_DIR)/block_batl.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.hh \
+   $(SPBL_SOURCE_DIR)/boundary_space.cc \
+   $(SPBL_SOURCE_DIR)/boundary_space.hh \
+   $(SPBL_SOURCE_DIR)/boundary_base.cc \
+   $(SPBL_SOURCE_DIR)/boundary_base.hh \
+   $(SPBL_SOURCE_DIR)/initial_space.cc \
+   $(SPBL_SOURCE_DIR)/initial_space.hh \
+   $(SPBL_SOURCE_DIR)/initial_momentum.cc \
+   $(SPBL_SOURCE_DIR)/initial_momentum.hh \
+   $(SPBL_SOURCE_DIR)/initial_base.cc \
+   $(SPBL_SOURCE_DIR)/initial_base.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_base.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.hh \
+   $(SPBL_SOURCE_DIR)/spectrum_interface.f90 \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/spatial_data.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_trajectory_batl_LDADD = -L$(BATL_HOME)/lib -lREADAMR -lTIMING -lSHARE -lgfortran -lmpi_mpifh $(GSL_LIBS)
+
+main_testread_SOURCES = main_testread.cc \
+   $(SPBL_SOURCE_DIR)/spectrum_interface.f90
+
+main_testread_LDADD = -L$(BATL_HOME)/lib -lREADAMR -lTIMING -lSHARE -lgfortran -lmpi_mpifh
+
+main_test_background_waves_SOURCES = main_test_background_waves.cc \
+   $(SPBL_SOURCE_DIR)/background_waves.cc \
+   $(SPBL_SOURCE_DIR)/background_waves.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/multi_index.cc \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/spatial_data.hh \
+   $(SPBL_COMMON_DIR)/turb_prop.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh \
+   $(SPBL_COMMON_DIR)/definitions.cc
+
+main_test_background_waves_LDADD = $(GSL_LIBS)
+
+main_test_background_mswave_SOURCES = main_test_background_mswave.cc \
+   $(SPBL_SOURCE_DIR)/background_mswave.cc \
+   $(SPBL_SOURCE_DIR)/background_mswave.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/spatial_data.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_background_mswave_LDADD = $(GSL_LIBS)
+
+main_simulation_lee_SOURCES = main_simulation_lee.cc \
+   $(SPBL_SOURCE_DIR)/simulation.cc \
+   $(SPBL_SOURCE_DIR)/simulation.hh \
+   $(SPBL_SOURCE_DIR)/distribution_other.cc \
+   $(SPBL_SOURCE_DIR)/distribution_other.hh \
+   $(SPBL_SOURCE_DIR)/distribution_base.cc \
+   $(SPBL_SOURCE_DIR)/distribution_base.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_lorentz.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_lorentz.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_base.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_base.hh \
+   $(SPBL_SOURCE_DIR)/background_waves.cc \
+   $(SPBL_SOURCE_DIR)/background_waves.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.hh \
+   $(SPBL_SOURCE_DIR)/boundary_time.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.hh \
+   $(SPBL_SOURCE_DIR)/boundary_base.cc \
+   $(SPBL_SOURCE_DIR)/boundary_base.hh \
+   $(SPBL_SOURCE_DIR)/initial_space.cc \
+   $(SPBL_SOURCE_DIR)/initial_space.hh \
+   $(SPBL_SOURCE_DIR)/initial_momentum.cc \
+   $(SPBL_SOURCE_DIR)/initial_momentum.hh \
+   $(SPBL_SOURCE_DIR)/initial_base.cc \
+   $(SPBL_SOURCE_DIR)/initial_base.hh \
+   $(SPBL_SOURCE_DIR)/traj_config.hh \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/rk_config.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_simulation_lee_LDADD = $(MPI_LIBS) $(GSL_LIBS)
+
+main_test_alfven_turb_SOURCES = main_test_alfven_turb.cc \
+   $(SPBL_SOURCE_DIR)/simulation.cc \
+   $(SPBL_SOURCE_DIR)/simulation.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_lorentz.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_lorentz.hh \
+   $(SPBL_SOURCE_DIR)/trajectory_base.cc \
+   $(SPBL_SOURCE_DIR)/trajectory_base.hh \
+   $(SPBL_SOURCE_DIR)/background_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/background_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/background_waves.cc \
+   $(SPBL_SOURCE_DIR)/background_waves.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/server_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/server_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/server_base.cc \
+   $(SPBL_SOURCE_DIR)/server_base.hh \
+   $(SPBL_SOURCE_DIR)/cache_lru.cc \
+   $(SPBL_SOURCE_DIR)/cache_lru.hh \
+   $(SPBL_SOURCE_DIR)/block_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/block_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/block_base.cc \
+   $(SPBL_SOURCE_DIR)/block_base.hh \
+   $(SPBL_SOURCE_DIR)/reader_cartesian.cc \
+   $(SPBL_SOURCE_DIR)/reader_cartesian.hh \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/boundary_momentum.cc \
+   $(SPBL_SOURCE_DIR)/boundary_momentum.hh \
+   $(SPBL_SOURCE_DIR)/boundary_space.cc \
+   $(SPBL_SOURCE_DIR)/boundary_space.hh \
+   $(SPBL_SOURCE_DIR)/boundary_time.cc \
+   $(SPBL_SOURCE_DIR)/boundary_time.hh \
+   $(SPBL_SOURCE_DIR)/boundary_base.cc \
+   $(SPBL_SOURCE_DIR)/boundary_base.hh \
+   $(SPBL_SOURCE_DIR)/initial_space.cc \
+   $(SPBL_SOURCE_DIR)/initial_space.hh \
+   $(SPBL_SOURCE_DIR)/initial_momentum.cc \
+   $(SPBL_SOURCE_DIR)/initial_momentum.hh \
+   $(SPBL_SOURCE_DIR)/initial_base.cc \
+   $(SPBL_SOURCE_DIR)/initial_base.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_other.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_other.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_base.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.hh \
+   $(SPBL_SOURCE_DIR)/distribution_other.cc \
+   $(SPBL_SOURCE_DIR)/distribution_other.hh \
+   $(SPBL_SOURCE_DIR)/distribution_templated.cc \
+   $(SPBL_SOURCE_DIR)/distribution_templated.hh \
+   $(SPBL_SOURCE_DIR)/distribution_base.cc \
+   $(SPBL_SOURCE_DIR)/distribution_base.hh \
+   $(SPBL_SOURCE_DIR)/traj_config.hh \
+   $(SPBL_SOURCE_DIR)/server_config.hh \
+   $(SPBL_SOURCE_DIR)/server_exceptions.hh \
+   $(SPBL_COMMON_DIR)/workload_manager.hh \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/turb_prop.hh \
+   $(SPBL_COMMON_DIR)/spatial_data.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/rk_config.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/multi_index.cc \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh \
+   $(SPBL_COMMON_DIR)/definitions.cc
+
+main_test_alfven_turb_LDADD = $(MPI_LIBS) $(GSL_LIBS)
+
+
+main_drawsector_SOURCES = main_drawsector.cc \
+   $(SPBL_GEODESIC_DIR)/drawable_sector.cc \
+   $(SPBL_GEODESIC_DIR)/drawable_sector.hh \
+   $(SPBL_GEODESIC_DIR)/geodesic_sector.cc \
+   $(SPBL_GEODESIC_DIR)/geodesic_sector.hh \
+   $(SPBL_GEODESIC_DIR)/polygonal_addressing.hh \
+   $(SPBL_GEODESIC_DIR)/polyhedron.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/gpu_config.hh
+
+
+main_tesstest_SOURCES = main_tesstest.cc \
+   $(SPBL_GEODESIC_DIR)/drawable_tesselation.cc \
+   $(SPBL_GEODESIC_DIR)/drawable_tesselation.hh \
+   $(SPBL_GEODESIC_DIR)/spherical_tesselation.cc \
+   $(SPBL_GEODESIC_DIR)/spherical_tesselation.hh \
+   $(SPBL_GEODESIC_DIR)/polyhedron.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/gpu_config.hh
+
+main_tesstest_LDADD = 
+
+#-----------------------------------------------------------------------------------------------------------------------------------------------------
+
+main_test_exchange_site_SOURCES = main_test_exchange_site.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/exchange_site.hh \
+   $(SPBL_COMMON_DIR)/communication_site.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh
+
+main_test_exchange_site_LDADD =
+
+#-----------------------------------------------------------------------------------------------------------------------------------------------------
+
+main_test_shared_site_SOURCES = main_test_shared_site.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/shared_site.hh \
+   $(SPBL_COMMON_DIR)/communication_site.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh
+
+main_test_shared_site_LDADD =
+
+#-----------------------------------------------------------------------------------------------------------------------------------------------------
+
+main_test_grid_block_SOURCES = main_test_grid_block.cc \
+   $(SPBL_GEODESIC_DIR)/grid_block.cc \
+   $(SPBL_GEODESIC_DIR)/grid_block.hh \
+   $(SPBL_GEODESIC_DIR)/geodesic_sector.cc \
+   $(SPBL_GEODESIC_DIR)/geodesic_sector.hh \
+   $(SPBL_GEODESIC_DIR)/polygonal_addressing.hh \
+   $(SPBL_GEODESIC_DIR)/spherical_slab.hh \
+   $(SPBL_GEODESIC_DIR)/traversable_tesselation.cc \
+   $(SPBL_GEODESIC_DIR)/traversable_tesselation.hh \
+   $(SPBL_GEODESIC_DIR)/requestable_tesselation.cc \
+   $(SPBL_GEODESIC_DIR)/requestable_tesselation.hh \
+   $(SPBL_GEODESIC_DIR)/spherical_tesselation.cc \
+   $(SPBL_GEODESIC_DIR)/spherical_tesselation.hh \
+   $(SPBL_GEODESIC_DIR)/polyhedron.hh \
+   $(SPBL_GEOMETRY_DIR)/distance_map.cc \
+   $(SPBL_GEOMETRY_DIR)/distance_map.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/gpu_config.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/simple_array.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_grid_block_LDADD = $(GSL_LIBS)
+
+#-----------------------------------------------------------------------------------------------------------------------------------------------------
+
+main_test_buffered_block_SOURCES = main_test_buffered_block.cc \
+   $(SPBL_GEODESIC_DIR)/buffered_block.cc \
+   $(SPBL_GEODESIC_DIR)/buffered_block.hh \
+   $(SPBL_GEODESIC_DIR)/stenciled_block.cc \
+   $(SPBL_GEODESIC_DIR)/stenciled_block.hh \
+   $(SPBL_GEODESIC_DIR)/grid_block.cc \
+   $(SPBL_GEODESIC_DIR)/grid_block.hh \
+   $(SPBL_GEODESIC_DIR)/geodesic_sector.cc \
+   $(SPBL_GEODESIC_DIR)/geodesic_sector.hh \
+   $(SPBL_GEODESIC_DIR)/polygonal_addressing.hh \
+   $(SPBL_GEODESIC_DIR)/spherical_slab.hh \
+   $(SPBL_GEODESIC_DIR)/traversable_tesselation.cc \
+   $(SPBL_GEODESIC_DIR)/traversable_tesselation.hh \
+   $(SPBL_GEODESIC_DIR)/requestable_tesselation.cc \
+   $(SPBL_GEODESIC_DIR)/requestable_tesselation.hh \
+   $(SPBL_GEODESIC_DIR)/spherical_tesselation.cc \
+   $(SPBL_GEODESIC_DIR)/spherical_tesselation.hh \
+   $(SPBL_GEODESIC_DIR)/polyhedron.hh \
+   $(SPBL_GEOMETRY_DIR)/distance_map.cc \
+   $(SPBL_GEOMETRY_DIR)/distance_map.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/exchange_site.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh \
+   $(SPBL_COMMON_DIR)/gpu_config.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/simple_array.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh
+
+main_test_buffered_block_LDADD = $(GSL_LIBS)
+

--- a/tests/main_test_buffered_block.cc
+++ b/tests/main_test_buffered_block.cc
@@ -1,0 +1,215 @@
+// mpicxx -I.. -Wall -Wno-comment -std=c++20 -DGEO_DEBUG -g -O0 -o main_test_buffered_block main_test_buffered_block.cc ../geometry/distance_map.cc ../geodesic/spherical_tesselation.cc ../geodesic/requestable_tesselation.cc ../geodesic/traversable_tesselation.cc ../geodesic/geodesic_sector.cc ../geodesic/grid_block.cc ../geodesic/stenciled_block.cc ../geodesic/grid_block.cc ../common/params.cc ../common/data_container.cc ../common/vectors.cc -lgsl -lgslcblas
+
+#include "geodesic/buffered_block.hh"
+#include "geodesic/traversable_tesselation.hh"
+
+using namespace Spectrum;
+
+//#define POLY_TYPE POLY_HEXAHEDRON
+#define POLY_TYPE POLY_ICOSAHEDRON
+#define MAX_FACE_DIVISION 5
+
+#if (POLY_TYPE == POLY_HEXAHEDRON)
+#define verts_per_face 4
+#else
+#define verts_per_face 3
+#endif
+
+const double rmin = 1.0;
+const double rmax = 2.0;
+
+const int sector_division = 0;
+const int face_division = 3;
+const int ghost_width = 2;
+const int sector_width = Pow2(face_division - sector_division);
+
+const int shells_per_slab = 8;
+const int n_slabs = 3;
+const int ghost_height = 2;
+
+int main(int argc, char *argv[])
+{
+   int edges_per_vert = EdgesAtVert<verts_per_face>();
+   int n_sect_parts_actual, sectors[edges_per_vert];
+   bool corners[verts_per_face];
+   bool borders[2];
+   int n_sectors, n_blocks, existing_sectors[2];
+
+   MPI_Config mpi_config(argc, argv);
+   int my_rank = MPI_Config::glob_comm_rank;
+   bool force_both_blocks_rank0 = false;
+
+   PrintMessage(__FILE__, __LINE__, "Size of glob commm is " + std::to_string(MPI_Config::glob_comm_size), MPI_Config::is_master);
+
+// Can only test with 1 or 2 processes
+   if(MPI_Config::work_comm_size > 2) return 1;
+
+// Create a Tesselation object
+   TraversableTesselation<POLY_TYPE, MAX_FACE_DIVISION> tesselation;
+   n_sectors = tesselation.NFaces(sector_division);
+   n_blocks = n_slabs * n_sectors;
+
+// Set up a radial map
+   DataContainer container;
+   container.Clear();
+   container.Insert(rmin);
+   container.Insert(rmax);
+   std::shared_ptr<DistanceBase> dist_map = std::make_shared<DistanceExponential>();
+   dist_map->SetupObject(container);
+
+// Currently both blocks are in the same slab - change this code to test TFACE, TEDGE, and VERTX exchanges
+   int existing_slab = 1;
+   borders[0] = (existing_slab == 0 ? true : false);
+   borders[1] = (existing_slab == n_slabs - 1 ? true : false);
+
+// Pick one vertex and two of its face neighbors - this allows testing RFACE or REDGE exchanges
+   int base_vert = 5;
+   n_sect_parts_actual = tesselation.FaceNeighborsOfVert(sector_division, base_vert, sectors);
+   existing_sectors[0] = sectors[2];
+   existing_sectors[1] = sectors[3];
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Create an array of blocks, as in DomainPartition::DomainPartition()
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+   std::vector<BufferedBlock<verts_per_face, int>> blocks_local;
+   int* face_index;
+   int* vert_index;
+   GeoVector* vcart;
+
+// Always allocate on rank 0, conditionally on rank 1
+   if ((my_rank == 0) || !force_both_blocks_rank0) {
+      blocks_local.emplace_back();
+      blocks_local.back().SetDimensions(sector_width, ghost_width, shells_per_slab, ghost_height, false);
+      blocks_local.back().SetIndex(existing_slab * n_sectors + existing_sectors[my_rank]);
+
+      face_index = new int[blocks_local.back().TotalFaces()];
+      vert_index = new int[blocks_local.back().TotalVerts()];
+      vcart = new GeoVector[blocks_local.back().TotalVerts()];
+
+      tesselation.GetAllInsideFaceNative(sector_division, existing_sectors[my_rank], face_division, ghost_width, face_index, vert_index, corners);
+      tesselation.FillVertCoordArrays(blocks_local.back().TotalVerts(), vert_index, vcart);
+      blocks_local.back().AssociateMesh(existing_slab / (double)n_slabs, (existing_slab + 1.0) / (double)n_slabs, corners, borders, vcart, dist_map, false);
+
+      delete[] face_index;
+      delete[] vert_index;
+      delete[] vcart;
+      std::cerr << "Block number " << blocks_local.back().GetIndex() << " created\n";
+   }
+
+// Serial run or both blocks forced on one process
+   if ((MPI_Config::work_comm_size == 1) || force_both_blocks_rank0) {
+      blocks_local.emplace_back();
+      blocks_local.back().SetDimensions(sector_width, ghost_width, shells_per_slab, ghost_height, false);
+      blocks_local.back().SetIndex(existing_slab * n_sectors + existing_sectors[1]);
+
+      face_index = new int[blocks_local.back().TotalFaces()];
+      vert_index = new int[blocks_local.back().TotalVerts()];
+      vcart = new GeoVector[blocks_local.back().TotalVerts()];
+
+      tesselation.GetAllInsideFaceNative(sector_division, existing_sectors[1], face_division, ghost_width, face_index, vert_index, corners);
+      tesselation.FillVertCoordArrays(blocks_local.back().TotalVerts(), vert_index, vcart);
+      blocks_local.back().AssociateMesh(existing_slab / (double)n_slabs, (existing_slab + 1.0) / (double)n_slabs, corners, borders, vcart, dist_map, false);
+
+      delete[] face_index;
+      delete[] vert_index;
+      delete[] vcart;
+      std::cerr << "Block number " << blocks_local.back().GetIndex() << " created\n";
+   };
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Create _all_ exchange sites of type REDGE as in DomainPartition::SetUpExchangeSites()
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+   int n_sites_sect, buf_size, sidx, part;
+   int ranks[2 * edges_per_vert], labels[2 * edges_per_vert], verts[verts_per_face];
+   std::vector<std::shared_ptr<ExchangeSite<int>>> exch_sites;
+   std::vector<int> exch_sites_local;
+   
+// A process might have no blocks, but the site still needs to be registered with correct buffer size
+   BufferedBlock<verts_per_face, int> block_temp;
+   block_temp.SetDimensions(sector_width, ghost_width, shells_per_slab, ghost_height, false);
+   buf_size = block_temp.GetBufferSize(GEONBR_REDGE);
+   PrintMessage(__FILE__, __LINE__, "Buffer size is " + std::to_string(buf_size), MPI_Config::is_master);
+
+   sidx = 0;
+   for (auto slab = 0; slab < n_slabs; slab++) {
+      for (auto vert = 0; vert < tesselation.NVerts(sector_division); vert++) {
+         exch_sites.emplace_back(std::make_shared<ExchangeSite<int>>());
+         n_sect_parts_actual = tesselation.FaceNeighborsOfVert(sector_division, vert, sectors);
+
+// Loop over participating sectors - only two exist, the rest are assigned MPI_PROC_NULL.
+         part = 0;
+         for (auto it = 0; it < n_sect_parts_actual; it++) {
+            labels[part] = slab * tesselation.NFaces(sector_division) + sectors[it];
+
+// The first block is always on process 0, while the second could be on either
+            if (sectors[it] == existing_sectors[0]) ranks[part] = 0;
+            else if (sectors[it] == existing_sectors[1]) {
+               if ((MPI_Config::work_comm_size == 1) || force_both_blocks_rank0) ranks[part] = 0;
+               else ranks[part] = 1;
+            }
+
+// All the other parts are missing, but a valid rank is required, so we use rank 0
+            else ranks[part] = 0;
+            part++;
+         };
+            
+// Initialize the exchange site and add it to the list if it is local to this process
+         exch_sites.back()->SetUpProperties(sidx, n_sect_parts_actual, buf_size, ranks, labels);
+         if (exch_sites.back()->GetCommSize() > 0) exch_sites_local.push_back(sidx);
+         exch_sites.back()->FillBuffers(-2);
+         sidx++;
+      };
+   };
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Inform the blocks about their exchange sites as in DomainPartition::ExportExchangeSites()
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+   std::vector<std::shared_ptr<ExchangeSite<int>>> exch_sites_block;
+
+   if(MPI_Config::is_master) std::cerr << std::endl;
+
+   for (auto block = 0; block < blocks_local.size(); block++) {
+      exch_sites_block.clear();
+      n_sites_sect = tesselation.VertNeighborsOfFace(sector_division, blocks_local[block].GetIndex() % n_sectors, verts);
+
+      for (auto iv = 0; iv < n_sites_sect; iv++) {
+         sidx = existing_slab * tesselation.NVerts(sector_division) + verts[iv];
+         exch_sites_block.push_back(exch_sites[sidx]);
+
+         if(MPI_Config::is_master) {
+            std::cerr << "Adding exchange site " << sidx << " to block " << blocks_local[block].GetIndex() << std::endl;
+         };
+
+      };
+      blocks_local[block].ImportExchangeSites(GEONBR_REDGE, exch_sites_block);
+   };
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// Perform the exchange as in DomainPartition::ExchangeAll(); most sites are empty and should not do anything at all
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+   std::cerr << std::endl;
+   for (auto site = 0; site < blocks_local[0].GetExchangeSiteCount(GEONBR_REDGE); site++) {
+      for (part = 0; part < blocks_local[0].GetPartCount(GEONBR_REDGE); part++) {
+         std::cerr << "Site " << site << " Part " << part << " face map:\n";
+         blocks_local[0].PrintBufferMap(GEONBR_REDGE, site, part);
+      };
+   };
+
+   blocks_local[0].FillWithIndexData();
+   blocks_local[1].FillWithIndexData();
+   blocks_local[0].PrintContents();
+
+   for (auto block = 0; block < blocks_local.size(); block++) blocks_local[block].PackBuffers(GEONBR_REDGE);
+   for (auto sidx : exch_sites_local) {
+      exch_sites[sidx]->Exchange();
+   };
+   for (auto block = 0; block < blocks_local.size(); block++) blocks_local[block].UnPackBuffers(GEONBR_REDGE);
+
+   blocks_local[0].PrintContents();
+
+};
+

--- a/tests/main_test_exchange_site.cc
+++ b/tests/main_test_exchange_site.cc
@@ -1,18 +1,15 @@
 // mpicxx -I.. -Wall -std=c++20 -DGEO_DEBUG -DUSE_SILO -g -O0 -o main_test_exchange_site main_test_exchange_site.cc ../common/mpi_config.cc
 // mpirun -n 10 --oversubscribe --host localhost:10 ./main_test_exchange_site
 
-#include <iostream>
-#include <iomanip>
 #include "common/exchange_site.hh"
 
 using namespace Spectrum;
 
-const int test_rank = 4;
+const int test_rank = 1;
 
 int main(int argc, char *argv[])
 {
    MPI_Config mpi_config(argc, argv);
    TestExchange(test_rank);
-   return 0;
 };
 

--- a/tests/main_test_grid_block.cc
+++ b/tests/main_test_grid_block.cc
@@ -6,10 +6,15 @@
 
 using namespace Spectrum;
 
-#define POLY_TYPE POLY_HEXAHEDRON
-//#define POLY_TYPE POLY_ICOSAHEDRON
-#define MAX_DIVISION 6
+//#define POLY_TYPE POLY_HEXAHEDRON
+#define POLY_TYPE POLY_ICOSAHEDRON
+#define MAX_FACE_DIVISION 5
+
+#if (POLY_TYPE == POLY_HEXAHEDRON)
 #define verts_per_face 4
+#else
+#define verts_per_face 3
+#endif
 
 const double rmin = 30.0;
 const double rmed = 300.0;
@@ -18,8 +23,8 @@ const double power_law = 10.0;
 const double fraction = 0.4;
 const double logy = 10.0;
 
-const int face_division = 6;
-const int sect_division = 0;
+const int face_division = 3;
+const int sector_division = 0;
 const int ghost_width = 2;
 
 const int slab_height = 720;
@@ -36,7 +41,7 @@ int main(int argc, char *argv[])
    borders[1] = (slab == n_slabs - 1 ? true : false);
 
 // Create a Tesselation object
-   TraversableTesselation<POLY_TYPE, MAX_DIVISION> tess;
+   TraversableTesselation<POLY_TYPE, MAX_FACE_DIVISION> tesselation;
 
 // Set up a radial map
    DataContainer container;
@@ -52,16 +57,16 @@ int main(int argc, char *argv[])
    dist_map->SetupObject(container);
 
 // Create one grid block
-   GridBlock<verts_per_face> block(Pow2(face_division - sect_division), ghost_width, slab_height, ghost_height);
+   GridBlock<verts_per_face> block(Pow2(face_division - sector_division), ghost_width, slab_height, ghost_height);
    block.SetIndex(0);
 
    int* face_index = new int[block.TotalFaces()];
    int* vert_index = new int[block.TotalVerts()];
    GeoVector* vcart = new GeoVector[block.TotalVerts()];
 
-   tess.GetAllInsideFaceNative(sect_division, sector, face_division, ghost_width, face_index, vert_index, corners);
+   tesselation.GetAllInsideFaceNative(sector_division, sector, face_division, ghost_width, face_index, vert_index, corners);
 
-   tess.FillVertCoordArrays(block.TotalVerts(), vert_index, vcart);
+   tesselation.FillVertCoordArrays(block.TotalVerts(), vert_index, vcart);
    block.AssociateMesh(slab / (double)n_slabs, (slab + 1.0) / (double)n_slabs, corners, borders, vcart, dist_map);
    block.PrintStats();
 //   block.DrawZone(3, 57, DegToRad(0.0), DegToRad(0.0));

--- a/tests/main_test_mpi_config.cc
+++ b/tests/main_test_mpi_config.cc
@@ -7,15 +7,9 @@
 
 using namespace Spectrum;
 
-// Create an instance of the class to initialize all MPI objects
-void InitializeMPI(int argc, char** argv)
-{
-   static MPI_Config mpi_config(argc, argv);
-};
-
 int main(int argc, char** argv)
 {
-   InitializeMPI(argc, argv);
+   MPI_Config mpi_config(argc, argv);
    TestMPIConfig();
 };
 

--- a/tests/main_test_shared_site.cc
+++ b/tests/main_test_shared_site.cc
@@ -1,0 +1,15 @@
+// mpicxx -I.. -Wall -std=c++20 -DGEO_DEBUG -DUSE_SILO -g -O0 -o main_test_shared_site main_test_shared_site.cc ../common/mpi_config.cc
+// mpirun -n 10 --oversubscribe --host localhost:10 ./main_test_shared_site
+
+#include "common/shared_site.hh"
+
+using namespace Spectrum;
+
+const int test_rank = 2;
+
+int main(int argc, char *argv[])
+{
+   MPI_Config mpi_config(argc, argv);
+   TestShared(test_rank);
+};
+


### PR DESCRIPTION
This update contains major changes to `BufferedBlock`. The buffer mapping function is working for the neighbor type `GEONBR_REDGE`, while others are untested. The `ExchangeSite` class was made a derivative of a more general `ComminicationSite` class. I created another derived class,`SharedSite`, that performs a reduction operation. The fluid conservation laws classes were also re-arranged: now conserved, primitive, and fluxes are nested within a conservation law class.