### PR TITLE
Update distribution_templated.cc

### DIFF
--- a/src/distribution_templated.cc
+++ b/src/distribution_templated.cc
@@ -146,20 +146,28 @@ void DistributionTemplated<distroClass>::AddEvent(void)
 {
    int ijk, lin_bin;
    MultiIndex bin = mi_zeros;
+   double val;
 
 // The event has been already processed and "_values" and "_weight" computed
    for (ijk = 0; ijk < 3; ijk++) {
 
 // Skip if dimension is ignorable
       if (BITS_LOWERED(dims, 1 << ijk)) continue;
-      bin[ijk] = ((log_bins[ijk] ? log10(_value[ijk]) : _value[ijk]) - limits[0][ijk]) / bin_size[ijk];
 
-// Check for outlying events
-      if (bin[ijk] < 0) {
+// Shift value relative to lower limit
+      val = (log_bins[ijk] ? log10(_value[ijk]) : _value[ijk]) - limits[0][ijk];
+     
+// Check for "left" outlier event
+      if (val < 0.0) {
          if (bin_outside[ijk]) bin[ijk] = 0;
          else return;
-      }
-      else if (bin[ijk] >= n_bins[ijk]) {
+      };
+
+// Compute bin for shifted value. Bin will not be negative but could be >= "n_bins".
+      bin[ijk] = val / bin_size[ijk];
+
+// Check for "right" outlier events
+      if (bin[ijk] >= n_bins[ijk]) {
          if (bin_outside[ijk]) bin[ijk] = n_bins[ijk] - 1;
          else return;
       };


### PR DESCRIPTION
The previous binning routine incorrectly assigned values just below the lower bin to the first bin due to integer rounding of floating points within (-1,0) to 0. This new version prevents that error by first checking if the value is below the lower bound, and only computing its bin if the value above the lower bound.