### PR TITLE
Created new background

### DIFF
--- a/src/background_discontinuity.cc
+++ b/src/background_discontinuity.cc
@@ -1,0 +1,111 @@
+/*!
+\file background_discontinuity.cc
+\brief Implements a simple planar MHD discontinuity background
+\author Juan G Alonso Guzman
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
+*/
+
+#include "background_discontinuity.hh"
+
+namespace Spectrum {
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// BackgroundDiscontinuity methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Juan G Alonso Guzman
+\date 10/20/2023
+*/
+BackgroundDiscontinuity::BackgroundDiscontinuity(void)
+                       : BackgroundBase(bg_name_discontinuity, 0, STATE_NONE)
+{
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 10/20/2023
+\param[in] other Object to initialize from
+
+A copy constructor should first first call the Params' version to copy the data container and then check whether the other object has been set up. If yes, it should simply call the virtual method "SetupBackground()" with the argument of "true".
+*/
+BackgroundDiscontinuity::BackgroundDiscontinuity(const BackgroundDiscontinuity& other)
+                       : BackgroundBase(other)
+{
+   RAISE_BITS(_status, STATE_NONE);
+   if (BITS_RAISED(other._status, STATE_SETUP_COMPLETE)) SetupBackground(true);
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 10/20/2023
+*/
+BackgroundDiscontinuity::BackgroundDiscontinuity(const std::string& name_in, unsigned int specie_in, uint16_t status_in)
+               : BackgroundBase(name_in, specie_in, status_in)
+{
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 05/14/2025
+\param [in] construct Whether called from a copy constructor or separately
+
+This method's main role is to unpack the data container and set up the class data members and status bits marked as "persistent". The function should assume that the data container is available because the calling function will always ensure this.
+*/
+void BackgroundDiscontinuity::SetupBackground(bool construct)
+{
+// The parent version must be called explicitly if not constructing
+   if (!construct) BackgroundBase::SetupBackground(false);
+
+// Unpack parameters
+   container.Read(n_discont);
+   container.Read(v_discont);
+   container.Read(u1);
+   container.Read(B1);
+
+// Normalize n_discont
+   n_discont.Normalize();
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 05/14/2025
+*/
+void BackgroundDiscontinuity::EvaluateBackground(void)
+{
+// Upstream
+   if ((_pos - r0 - v_discont * n_discont * _t) * n_discont > 0) {
+      if (BITS_RAISED(_spdata._mask, BACKGROUND_U)) _spdata.Uvec = u0;
+      if (BITS_RAISED(_spdata._mask, BACKGROUND_B)) _spdata.Bvec = B0;
+      _spdata.region = 1.0;
+   }
+// Downstream
+   else {
+      if (BITS_RAISED(_spdata._mask, BACKGROUND_U)) _spdata.Uvec = u1;
+      if (BITS_RAISED(_spdata._mask, BACKGROUND_B)) _spdata.Bvec = B1;
+      _spdata.region = 2.0;
+   };
+   
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_E)) _spdata.Evec = -(_spdata.Uvec ^ _spdata.Bvec) / c_code;
+   LOWER_BITS(_status, STATE_INVALID);
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 10/14/2022
+*/
+void BackgroundDiscontinuity::EvaluateBackgroundDerivatives(void)
+{
+// Spatial derivatives are zero
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_gradU)) _spdata.gradUvec = gm_zeros;
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_gradB)) _spdata.gradBvec = gm_zeros;
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_gradE)) _spdata.gradEvec = gm_zeros;
+
+// Time derivatives are zero
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_dUdt)) _spdata.dUvecdt = gv_zeros;
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_dBdt)) _spdata.dBvecdt = gv_zeros;
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_dEdt)) _spdata.dEvecdt = gv_zeros;
+};
+
+};

--- a/src/background_discontinuity.cc
+++ b/src/background_discontinuity.cc
@@ -75,7 +75,7 @@ void BackgroundDiscontinuity::SetupBackground(bool construct)
 void BackgroundDiscontinuity::EvaluateBackground(void)
 {
 // Upstream
-   if ((_pos - r0 - v_discont * n_discont * _t) * n_discont > 0) {
+   if ((_pos - r0) * n_discont - v_discont * _t > 0) {
       if (BITS_RAISED(_spdata._mask, BACKGROUND_U)) _spdata.Uvec = u0;
       if (BITS_RAISED(_spdata._mask, BACKGROUND_B)) _spdata.Bvec = B0;
       _spdata.region = 1.0;

--- a/src/background_discontinuity.hh
+++ b/src/background_discontinuity.hh
@@ -1,0 +1,74 @@
+/*!
+\file background_discontinuity.hh
+\brief Declares a simple planar MHD discontinuity field background
+\author Juan G Alonso Guzman
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a SHOCK coverage of the surface of a sphere.
+*/
+
+#ifndef SPECTRUM_BACKGROUND_DISCONTINUITY_HH
+#define SPECTRUM_BACKGROUND_DISCONTINUITY_HH
+
+#include "background_base.hh"
+
+namespace Spectrum {
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// BackgroundDiscontinuity class declaration
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+//! Readable name of the BackgroundDiscontinuity class
+const std::string bg_name_discontinuity = "BackgroundDiscontinuity";
+
+/*!
+\brief Planar MHD dicontinuity
+\author Juan G Alonso Guzman
+
+Parameters: (BackgroundBase), GeoVector n_discont, double v_discont, GeoVector u1, GeoVector B1
+*/
+class BackgroundDiscontinuity : public BackgroundBase {
+
+protected:
+
+//! Discontinuity normal (persistent)
+   GeoVector n_discont;
+
+//! Discontinuity velocity (persistent)
+   double v_discont;
+
+//! Downstream flow vector (persistent), "u0" is upstream flow vector
+   GeoVector u1;
+
+//! Downstream magnetic field (persistent), "B0" is upstream magnetic field
+   GeoVector B1;
+
+//! Set up the field evaluator based on "params"
+   void SetupBackground(bool construct) override;
+
+//! Compute the internal u, B, and E fields
+   void EvaluateBackground(void) override;
+
+//! Compute the internal u, B, and E derivatives
+   void EvaluateBackgroundDerivatives(void) override;
+
+public:
+
+//! Default constructor
+   BackgroundDiscontinuity(void);
+
+//! Constructor with arguments (to speed up construction of derived classes)
+   BackgroundDiscontinuity(const std::string& name_in, unsigned int specie_in, uint16_t status_in);
+
+//! Copy constructor
+   BackgroundDiscontinuity(const BackgroundDiscontinuity& other);
+
+//! Destructor
+   ~BackgroundDiscontinuity() override = default;
+
+//! Clone function
+   CloneFunctionBackground(BackgroundDiscontinuity);
+};
+
+};
+
+#endif

--- a/src/background_shock.cc
+++ b/src/background_shock.cc
@@ -94,8 +94,8 @@ void BackgroundShock::EvaluateBackground(void)
    }
 // Downstream
    else {
-      if (BITS_RAISED(_spdata._mask, BACKGROUND_U)) _spdata.Uvec = u1
-      if (BITS_RAISED(_spdata._mask, BACKGROUND_B)) _spdata.Bvec = B1
+      if (BITS_RAISED(_spdata._mask, BACKGROUND_U)) _spdata.Uvec = u1;
+      if (BITS_RAISED(_spdata._mask, BACKGROUND_B)) _spdata.Bvec = B1;
       _spdata.region = 2.0;
    };
 

--- a/src/background_shock.cc
+++ b/src/background_shock.cc
@@ -87,7 +87,7 @@ void BackgroundShock::SetupBackground(bool construct)
 void BackgroundShock::EvaluateBackground(void)
 {
 // Upstream
-   if ((_pos - r0 - v_shock * n_shock * _t) * n_shock > 0) {
+   if ((_pos - r0) * n_shock - v_shock * _t > 0) {
       if (BITS_RAISED(_spdata._mask, BACKGROUND_U)) _spdata.Uvec = u0;
       if (BITS_RAISED(_spdata._mask, BACKGROUND_B)) _spdata.Bvec = B0;
       _spdata.region = 1.0;

--- a/src/background_shock.hh
+++ b/src/background_shock.hh
@@ -40,10 +40,10 @@ protected:
    double compression;
 
 //! Downstream velocity (persistent), "u0" is upstream flow vector
-   double u1;
+   GeoVector u1;
 
 //! Downstream magnetic field (persistent), "B0" is upstream magnetic field
-   double B1;
+   GeoVector B1;
 
 //! Set up the field evaluator based on "params"
    void SetupBackground(bool construct) override;

--- a/src/background_shock.hh
+++ b/src/background_shock.hh
@@ -1,6 +1,6 @@
 /*!
 \file background_shock.hh
-\brief Declares a simple shock field background
+\brief Declares a simple planar shock field background
 \author Juan G Alonso Guzman
 
 This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a SHOCK coverage of the surface of a sphere.
@@ -21,10 +21,10 @@ namespace Spectrum {
 const std::string bg_name_shock = "BackgroundShock";
 
 /*!
-\brief Constant EM field, mainly for testing
+\brief Planar MHD shock
 \author Juan G Alonso Guzman
 
-Parameters: (BackgroundBase), GeoVector n_shock, double v_shock, GeoVector u1, GeoVector B1
+Parameters: (BackgroundBase), GeoVector n_shock, double v_shock, double compression
 */
 class BackgroundShock : public BackgroundBase {
 
@@ -36,11 +36,14 @@ protected:
 //! Shock velocity (persistent)
    double v_shock;
 
-//! Downstream flow vector (persistent), "u0" is upstream flow vector
-   GeoVector u1;
+//! Compression ratio (persistent)
+   double compression;
+
+//! Downstream velocity (persistent), "u0" is upstream flow vector
+   double u1;
 
 //! Downstream magnetic field (persistent), "B0" is upstream magnetic field
-   GeoVector B1;
+   double B1;
 
 //! Set up the field evaluator based on "params"
    void SetupBackground(bool construct) override;

--- a/src/background_smooth_discontinuity.cc
+++ b/src/background_smooth_discontinuity.cc
@@ -1,0 +1,181 @@
+/*!
+\file background_smooth_discontinuity.cc
+\brief Implements a smooth discontinuity field background
+\author Juan G Alonso Guzman
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
+*/
+
+#include "background_smooth_discont.hh"
+
+namespace Spectrum {
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// BackgroundSmoothDiscontinuity methods
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+/*!
+\author Juan G Alonso Guzman
+\date 10/20/2023
+*/
+BackgroundSmoothDiscontinuity::BackgroundSmoothDiscontinuity(void)
+                             : BackgroundShock(bg_name_smooth_discontinuity, 0, STATE_NONE)
+{
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 10/20/2023
+\param[in] other Object to initialize from
+
+A copy constructor should first first call the Params' version to copy the data container and then check whether the other object has been set up. If yes, it should simply call the virtual method "SetupBackground()" with the argument of "true".
+*/
+BackgroundSmoothDiscontinuity::BackgroundSmoothDiscontinuity(const BackgroundSmoothDiscontinuity& other)
+                             : BackgroundShock(other)
+{
+   RAISE_BITS(_status, STATE_NONE);
+   if (BITS_RAISED(other._status, STATE_SETUP_COMPLETE)) SetupBackground(true);
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 05/30/2024
+\param [in] x Relative transition region location
+\return Relative value of discontinuous quantity
+*/
+double BackgroundSmoothDiscontinuity::DiscontinuityTransition(double x)
+{
+   double y = x + 0.5;
+#if SMOOTH_DISCONT_ORDER == 0 // continous but not differentiable
+   if (x < -0.5) return 0.0;
+   else if (x > 0.5) return 1.0;
+   else return y;
+#elif SMOOTH_DISCONT_ORDER == 1 // differentiable
+   if (x < -0.5) return 0.0;
+   else if (x > 0.5) return 1.0;
+   else return Sqr(y) * (3.0 - 2.0 * y);
+#elif SMOOTH_DISCONT_ORDER == 2 // twice differentiable
+   if (x < -0.5) return 0.0;
+   else if (x > 0.5) return 1.0;
+   else return Cube(y) * (10.0 - 15.0 * y + 6.0 * Sqr(y));
+#elif SMOOTH_DISCONT_ORDER == 3 // thrice differentiable
+   if (x < -0.5) return 0.0;
+   else if (x > 0.5) return 1.0;
+   else return Sqr(Sqr(y)) * (35.0 - 84.0 * y + 70.0 * Sqr(y) - 20.0 * Cube(y));
+#else // smooth
+   return 0.5 * (1.0 + tanh(tanh_width_factor * x));
+#endif
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 05/30/2024
+\param [in] x Relative transition region location 
+\return Derivative of relative value of discontinuous quantity
+*/
+double BackgroundSmoothDiscontinuity::DiscontinuityTransitionDerivative(double x)
+{
+   double y = x + 0.5;
+#if SMOOTH_DISCONT_ORDER == 0
+   if (x < -0.5) return 0.0;
+   else if (x > 0.5) return 0.0;
+   else return 1.0;
+#elif SMOOTH_DISCONT_ORDER == 1
+   if (x < -0.5) return 0.0;
+   else if (x > 0.5) return 0.0;
+   else return 6.0 * y * (1.0 - y);
+#elif SMOOTH_DISCONT_ORDER == 2
+   if (x < -0.5) return 0.0;
+   else if (x > 0.5) return 0.0;
+   else return 30.0 * Sqr(y) * (1.0 - 2.0 * y + Sqr(y));
+#elif SMOOTH_DISCONT_ORDER == 3
+   if (x < -0.5) return 0.0;
+   else if (x > 0.5) return 0.0;
+   else return 140.0 * Cube(y) * (1.0 - 3.0 * y + 3.0 * Sqr(y) - 1.0 * Cube(y));
+#else
+   return 0.5 * tanh_width_factor * (1.0 - Sqr(tanh(tanh_width_factor * x)));
+#endif
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 02/28/2025
+\param [in] construct Whether called from a copy constructor or separately
+
+This method's main role is to unpack the data container and set up the class data members and status bits marked as "persistent". The function should assume that the data container is available because the calling function will always ensure this.
+*/
+void BackgroundSmoothDiscontinuity::SetupBackground(bool construct)
+{
+// The parent version must be called explicitly if not constructing
+   if (!construct) BackgroundShock::SetupBackground(false);
+
+// Unpack parameters
+   container.Read(width_discont);
+   container.Read(dmax_fraction);
+   dmax_limit = dmax0 / (dmax_fraction * width_discont);
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 05/14/2025
+*/
+void BackgroundSmoothDiscontinuity::EvaluateBackground(void)
+{
+   double a1, a2;
+   ds_discont = ((_pos - r0) * n_discont - v_discont * _t) / width_discont;
+
+   a1 = ShockTransition(ds_discont);
+   a2 = 1.0 - a1;
+
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_U)) _spdata.Uvec = u0 * a1 + u1 * a2;
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_B)) _spdata.Bvec = B0 * a1 + B1 * a2;
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_E)) _spdata.Evec = -(_spdata.Uvec ^ _spdata.Bvec) / c_code;
+   _spdata.region = 1.0 * a1 + 2.0 * a2; // same as 2.0 - a1
+
+   LOWER_BITS(_status, STATE_INVALID);
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 10/20/2023
+*/
+void BackgroundSmoothDiscontinuity::EvaluateBackgroundDerivatives(void)
+{
+#if SMOOTHDISCONT_DERIVATIVE_METHOD == 0
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_gradU)) {
+      _spdata.gradUvec.Dyadic(n_discont, u0 - u1);
+      _spdata.gradUvec *= ShockTransitionDerivative(ds_discont) / width_discont;
+   };
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_gradB)) {
+      _spdata.gradBvec.Dyadic(n_discont, B0 - B1);
+      _spdata.gradBvec *= ShockTransitionDerivative(ds_discont) / width_discont;
+      _spdata.gradBmag = _spdata.gradBvec * _spdata.bhat;
+   };
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_gradE)) {
+      _spdata.gradEvec = -((_spdata.gradUvec ^ _spdata.Bvec) + (_spdata.Uvec ^ _spdata.gradBvec)) / c_code;
+   };
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_dUdt)) {
+      _spdata.dUvecdt = (ShockTransitionDerivative(ds_discont) * v_discont / width_discont) * (u1 - u0);
+   };
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_dBdt)) {
+      _spdata.dBvecdt = (ShockTransitionDerivative(ds_discont) * v_discont / width_discont) * (B1 - B0);
+   };
+   if (BITS_RAISED(_spdata._mask, BACKGROUND_dEdt)) {
+      _spdata.dEvecdt = -((_spdata.dUvecdt ^ _spdata.Bvec) + (_spdata.Uvec ^ _spdata.dBvecdt)) / c_code;
+   };
+#else
+   NumericalDerivatives();
+#endif
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 02/28/2025
+*/
+void BackgroundSmoothDiscontinuity::EvaluateDmax(void)
+{
+   _spdata.dmax = fmin(dmax_fraction * width_discont * fmax(1.0, fabs(ds_discont)), dmax0);
+   LOWER_BITS(_status, STATE_INVALID);
+};
+
+};

--- a/src/background_smooth_discontinuity.hh
+++ b/src/background_smooth_discontinuity.hh
@@ -1,0 +1,89 @@
+/*!
+\file background_smooth_discontinuity.hh
+\brief Declares a smooth MHD discontinuity field background
+\author Juan G Alonso Guzman
+
+This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a SHOCK coverage of the surface of a sphere.
+*/
+
+#ifndef SPECTRUM_BACKGROUND_SMOOTH_SHOCK_HH
+#define SPECTRUM_BACKGROUND_SMOOTH_SHOCK_HH
+
+#include "background_discontinuity.hh"
+
+namespace Spectrum {
+
+//! Flag to control smoothness of discontinuity
+#define SMOOTH_DISCONT_ORDER 4
+
+//! Method for computing derivatives (0: analytical, 1: numerical)
+#define SMOOTHDISCONT_DERIVATIVE_METHOD 0
+
+//! Scaling factor to better match discontinuity width when using smooth discontinuity (tanh)
+const double tanh_width_factor = 4.0;
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+// BackgroundSmoothDiscontinuity class declaration
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+//! Readable name of the BackgroundSmoothDiscontinuity class
+const std::string bg_name_smooth_discontinuity = "BackgroundSmoothDiscontinuity";
+
+/*!
+\brief Planar MHD discontinuity with a smooth transition region
+\author Juan G Alonso Guzman
+
+Parameters: (BackgroundShock), double width_discont, double dmax_fraction
+*/
+class BackgroundSmoothDiscontinuity : public BackgroundShock {
+
+protected:
+
+//! Width of discontinuity transition region (persistent)
+   double width_discont;
+
+//! Fraction of the discontinuity width to assign to dmax near discontinuity (persistent)
+   double dmax_fraction;
+
+//! Distance from discontinuity within which to modify dmax
+   double dmax_limit;
+
+//! Relative distance to discontinuity (transient)
+   double ds_discont;
+
+//! Shock transition region function
+   double DiscontinuityTransition(double x);
+
+//! Derivative of discontinuity transition region function
+   double DiscontinuityTransitionDerivative(double x);
+
+//! Set up the field evaluator based on "params"
+   void SetupBackground(bool construct) override;
+
+//! Compute the internal u, B, and E fields
+   void EvaluateBackground(void) override;
+
+//! Compute the internal u, B, and E derivatives
+   void EvaluateBackgroundDerivatives(void) override;
+
+//! Compute the maximum distance per time step
+   void EvaluateDmax(void) override;
+
+public:
+
+//! Default constructor
+   BackgroundSmoothDiscontinuity(void);
+
+//! Copy constructor
+   BackgroundSmoothDiscontinuity(const BackgroundSmoothDiscontinuity& other);
+
+//! Destructor
+   ~BackgroundSmoothDiscontinuity() override = default;
+
+//! Clone function
+   CloneFunctionBackground(BackgroundSmoothDiscontinuity);
+};
+
+};
+
+#endif

--- a/src/background_smooth_shock.cc
+++ b/src/background_smooth_shock.cc
@@ -127,6 +127,7 @@ void BackgroundSmoothShock::EvaluateBackground(void)
    a1 = ShockTransition(ds_shock);
    a2 = 1.0 - a1;
 
+// TODO: Change the way Bvec transitions to depend directly on Uvec to keep some product constant
    if (BITS_RAISED(_spdata._mask, BACKGROUND_U)) _spdata.Uvec = u0 * a1 + u1 * a2;
    if (BITS_RAISED(_spdata._mask, BACKGROUND_B)) _spdata.Bvec = B0 * a1 + B1 * a2;
    if (BITS_RAISED(_spdata._mask, BACKGROUND_E)) _spdata.Evec = -(_spdata.Uvec ^ _spdata.Bvec) / c_code;

--- a/src/background_smooth_shock.hh
+++ b/src/background_smooth_shock.hh
@@ -1,6 +1,6 @@
 /*!
 \file background_smooth_shock.hh
-\brief Declares a smooth shock field background
+\brief Declares a smooth MHD shock field background
 \author Juan G Alonso Guzman
 
 This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a SHOCK coverage of the surface of a sphere.
@@ -30,7 +30,7 @@ const double tanh_width_factor = 4.0;
 const std::string bg_name_smooth_shock = "BackgroundSmoothShock";
 
 /*!
-\brief Constant EM field with a smooth transition region
+\brief Planar MHD shock with a smooth transition region
 \author Juan G Alonso Guzman
 
 Parameters: (BackgroundShock), double width_shock, double dmax_fraction


### PR DESCRIPTION
The former shock backgrounds have been renamed to discontinuity backgrounds. The background now called shock follows proper MHD jump conditions once a compression ratio is specified, while the discontinuity backgrounds remain fully customizable downstream. The documenation has been edited to reflect this change.