### PR TITLE
Update boundary_momentum.cc

### DIFF
--- a/src/boundary_momentum.cc
+++ b/src/boundary_momentum.cc
@@ -218,7 +218,7 @@ void BoundaryMomentumInjectRestrictSlab::EvaluateBoundary(void)
 
 // If the momentum boundary crossing occurred outside the slab, "_delta_old" is reset to have the same sign as "_delta" to avoid triggering the crossing event.
    if (_delta * _delta_old < 0.0) {
-      if (((_pos - r0) * normal < 0.0) || ((_pos - r1) * normal > 0.0)) _delta_old = _delta;
+      if (((_pos - r0) * normal) * ((_pos - r1) * normal) > 0.0) _delta_old = _delta;
    };
 };
 


### PR DESCRIPTION
The boundary crossing condition in BoundaryMomentumInjectRestrictSlab is not generic enough, and assumes a specific orientation of `normal` and the two slabs. It has been replaced with a more general condition that works for either orientation.