### PR TITLE
Minor fixes for the geodesic mesh code and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SPECTRUM is capable of performing test-particle simulations for a variety of tra
 
 ### MHD Simulations
 
-This functionality of SPECTRUM is currently under development.
+SPECTRUM contains an adaptive geodesic mesh framework for systems of conservation conservation laws, such as MHD. Currently under development, the code will feature divergence-free conservative WENO reconstruction and a selection of Riemann solvers.
 
 ## Using the Code
 

--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,18 @@ AS_IF([test "x$enable_gsl" == "x"], [
 ])
 AM_CONDITIONAL([ENABLE_GSL], [test "x$HAVE_GSL" = x1])
 
+# Check for cxxopts
+HAVE_CXXOPTS=0
+AC_CHECK_HEADER([cxxopts.hpp], [
+   AC_MSG_NOTICE([cxxopts library found successfully])
+   AC_DEFINE([USE_CXXOPTS], [1], [Using cxxopts])
+   HAVE_CXXOPTS=1
+],
+[
+   AC_MSG_WARN([cxxopts library was not found - some of the functionality might be unavailable])
+])
+AM_CONDITIONAL([ENABLE_CXXOPTS], [test "x$HAVE_CXXOPTS" = x1])
+
 # Check for SILO
 HAVE_SILO=0
 AC_ARG_ENABLE([silo], [AS_HELP_STRING([--enable-silo], [enable SILO [default=no]])], [], [])
@@ -155,7 +167,7 @@ AS_IF([test "x$enable_silo" == "x"], [
       HAVE_SILO=1
    ],
    [
-      AC_MSG_WARN([SILO was not found])
+      AC_MSG_WARN([SILO library was not found - some of the functionality might be unavailable])
    ])
 ])
 AM_CONDITIONAL([ENABLE_SILO], [test "x$HAVE_SILO" = x1])
@@ -185,7 +197,9 @@ AS_IF([test "x$with_batl" == "x"], [
       [
          AC_MSG_WARN([BATL not found])
       ],
-      [$MPI_LIBS -lmpi_mpifh -lTIMING -lSHARE -lgfortran]) 
+      [
+         $MPI_LIBS -lmpi_mpifh -lTIMING -lSHARE -lgfortran
+      ])
    ],
    [
       AC_MSG_WARN([BATL lib or include directory does not exist])
@@ -352,3 +366,4 @@ AC_CHECK_FUNCS([floor memset pow sqrt])
 AC_CONFIG_FILES([Makefile runs/Makefile tests/Makefile benchmarks/Makefile])
 
 AC_OUTPUT
+

--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ AS_IF([test "x$with_batl" == "x"], [
       LDFLAGS="$LDFLAGS -L$BATL_LIBDIR"
 
 # Adds the found library to LIBS
-      AC_SEARCH_LIBS([wrapamr_read_header], [WRAPAMR wrapamr], [
+      AC_SEARCH_LIBS([wrapamr_read_header], [READAMR WRAPAMR wrapamr], [
          AC_DEFINE([USE_BATL], [1], [Using BATL])
          AC_MSG_NOTICE([BATL is enabled])
          HAVE_BATL=1
@@ -184,7 +184,8 @@ AS_IF([test "x$with_batl" == "x"], [
       ],
       [
          AC_MSG_WARN([BATL not found])
-      ]) 
+      ],
+      [$MPI_LIBS -lmpi_mpifh -lTIMING -lSHARE -lgfortran]) 
    ],
    [
       AC_MSG_WARN([BATL lib or include directory does not exist])
@@ -351,4 +352,3 @@ AC_CHECK_FUNCS([floor memset pow sqrt])
 AC_CONFIG_FILES([Makefile runs/Makefile tests/Makefile benchmarks/Makefile])
 
 AC_OUTPUT
-

--- a/geodesic/drawable_tesselation.cc
+++ b/geodesic/drawable_tesselation.cc
@@ -32,7 +32,7 @@ void DrawableTesselation<poly_type, max_division>::DrawGridArcs(int div, bool op
 
 // A drawing would be too busy for division values greated than 6
    if (div > 6) {
-      std::cerr << "Tesselation: Division too high for a plot\n";
+      PrintMessage(__FILE__, __LINE__, "Tesselation: Division too high for a plot", true);
       return;
    };
 
@@ -48,7 +48,7 @@ void DrawableTesselation<poly_type, max_division>::DrawGridArcs(int div, bool op
 
    GeoVector v, v1, v2, v3;
    std::ofstream meshfile;
-   meshfile.open(("mesh_" + std::to_string(poly_type) + "_" + std::to_string(div) + ".out").c_str(), std::ofstream::out);
+   meshfile.open(("mesh_" + std::string(PolyNames[static_cast<int>(poly_type)]) + "_" + std::to_string(div) + ".out").c_str(), std::ofstream::out);
    meshfile << "# Drawing edges at division " << div << std::endl;
 
 // Loop over edges
@@ -334,22 +334,22 @@ void DrawableTesselation<poly_type, max_division>::PrintConn(int div, int type) 
 
 #endif
 
-template class DrawableTesselation<POLY_TETRAHEDRON, 5>;
-template class DrawableTesselation<POLY_HEXAHEDRON, 5>;
-template class DrawableTesselation<POLY_OCTAHEDRON, 5>;
-template class DrawableTesselation<POLY_DODECAHEDRON, 5>;
-template class DrawableTesselation<POLY_ICOSAHEDRON, 5>;
+template class DrawableTesselation<PolyType::POLY_TETRAHEDRON, 5>;
+template class DrawableTesselation<PolyType::POLY_HEXAHEDRON, 5>;
+template class DrawableTesselation<PolyType::POLY_OCTAHEDRON, 5>;
+template class DrawableTesselation<PolyType::POLY_DODECAHEDRON, 5>;
+template class DrawableTesselation<PolyType::POLY_ICOSAHEDRON, 5>;
 
-template class DrawableTesselation<POLY_TETRAHEDRON, 6>;
-template class DrawableTesselation<POLY_HEXAHEDRON, 6>;
-template class DrawableTesselation<POLY_OCTAHEDRON, 6>;
-template class DrawableTesselation<POLY_DODECAHEDRON, 6>;
-template class DrawableTesselation<POLY_ICOSAHEDRON, 6>;
+template class DrawableTesselation<PolyType::POLY_TETRAHEDRON, 6>;
+template class DrawableTesselation<PolyType::POLY_HEXAHEDRON, 6>;
+template class DrawableTesselation<PolyType::POLY_OCTAHEDRON, 6>;
+template class DrawableTesselation<PolyType::POLY_DODECAHEDRON, 6>;
+template class DrawableTesselation<PolyType::POLY_ICOSAHEDRON, 6>;
 
-template class DrawableTesselation<POLY_TETRAHEDRON, 7>;
-template class DrawableTesselation<POLY_HEXAHEDRON, 7>;
-template class DrawableTesselation<POLY_OCTAHEDRON, 7>;
-template class DrawableTesselation<POLY_DODECAHEDRON, 7>;
-template class DrawableTesselation<POLY_ICOSAHEDRON, 7>;
+template class DrawableTesselation<PolyType::POLY_TETRAHEDRON, 7>;
+template class DrawableTesselation<PolyType::POLY_HEXAHEDRON, 7>;
+template class DrawableTesselation<PolyType::POLY_OCTAHEDRON, 7>;
+template class DrawableTesselation<PolyType::POLY_DODECAHEDRON, 7>;
+template class DrawableTesselation<PolyType::POLY_ICOSAHEDRON, 7>;
 
 };

--- a/geodesic/drawable_tesselation.hh
+++ b/geodesic/drawable_tesselation.hh
@@ -9,7 +9,7 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 #ifndef SPECTRUM_DRAWABLE_TESSELATION_HH
 #define SPECTRUM_DRAWABLE_TESSELATION_HH
 
-#include "geodesic/spherical_tesselation.hh"
+#include <geodesic/spherical_tesselation.hh>
 
 namespace Spectrum {
 

--- a/geodesic/geodesic_sector.cc
+++ b/geodesic/geodesic_sector.cc
@@ -723,27 +723,27 @@ void GeodesicSector<verts_per_face>::PrintConn(int type) const
       break;
 
    case 4:
-      std::cerr << "Printing edge-vert connectivity for block\n";
+      std::cerr << "Printing edge-vert connectivity\n";
       PrintConnectivity(n_edges_withghost, 2, 0, ev_local);
       break;
 
    case 6:
-      std::cerr << "Printing edge-face connectivity for block\n";
+      std::cerr << "Printing edge-face connectivity\n";
       PrintConnectivity(n_edges_withghost, 2, 0, ef_local);
       break;
 
    case 7:
-      std::cerr << "Printing face-vert connectivity for block\n";
+      std::cerr << "Printing face-vert connectivity\n";
       PrintConnectivity(n_faces_withghost, verts_per_face, 0, fv_local);
       break;
 
    case 8:
-      std::cerr << "Printing face-edge connectivity for block\n";
+      std::cerr << "Printing face-edge connectivity\n";
       PrintConnectivity(n_faces_withghost, verts_per_face, 0, fe_local);
       break;
 
    case 9:
-      std::cerr << "Printing face-face connectivity for block\n";
+      std::cerr << "Printing face-face connectivity\n";
       PrintConnectivity(n_faces_withghost, verts_per_face, 0, ff_local);
       break;
    };
@@ -805,6 +805,6 @@ void GeodesicSector<verts_per_face>::PrintMask(int type) const
 #endif
 
 template class GeodesicSector<3>;
-//template class GeodesicSector<4>;
+template class GeodesicSector<4>;
 
 };

--- a/geodesic/polygonal_addressing.hh
+++ b/geodesic/polygonal_addressing.hh
@@ -12,18 +12,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 namespace Spectrum {
 
 /*!
-\brief Number of edges at a vertex in an infinite tesselation
-\author Vladimir Florinski
-\date 07/02/2024
-\return Number of edges meeting at a vertex (3->6, 4->4, 6->3)
-*/
-template <int verts_per_face>
-static constexpr int EdgesAtVert(void)
-{
-   return 2 * verts_per_face / (verts_per_face - 2);
-};
-
-/*!
 \brief A class describing the Triangular Addressing Scheme (TAS) and Quad Addressing Scheme (QAS)
 \author Vladimir Florinski
 
@@ -165,7 +153,7 @@ inline constexpr void PolygonalAddressing<3>::StaticSetup(void)
    edge_djmax[0] =  0; edge_djmax[1] = -1; edge_djmax[2] =  0;
 
 /*              vertex-vertex                   vertex-edge                    vertex-face
-  
+
                  4         3                    -         -     	       -----------
                                                  \       /      	      / \	/ \
                                                   4     3       	     /   \  4  /   \
@@ -200,9 +188,9 @@ inline constexpr void PolygonalAddressing<3>::StaticSetup(void)
    vert_face[5][0] = -1; vert_face[5][1] =  0;
 
 /*                           edge-vertex                                                 edge-face 
-  
+
                type 0            type 1          type 2             type 0                 type 1                    type 2
-  
+
                                  1                    0               -                    -----------          -----------
                                   \                  /               / \                  / \       /            \       / \
                                    \                /               /   \                /   \  1  /              \  1  /   \
@@ -224,7 +212,7 @@ inline constexpr void PolygonalAddressing<3>::StaticSetup(void)
    edge_face[2][0][0] =  0; edge_face[2][0][1] =  0; edge_face[2][1][0] =  0; edge_face[2][1][1] =  1;
 
 /*               face-vertex                      face-edge                                  face-face
-  
+
                  2     1---------0               -     -----0-----          ---------------------          -
                 / \     \       /               / \     \       /            \       / \       /          / \
                /   \     \     /               /   \     1     2              \  2  /   \  1  /          /   \
@@ -281,7 +269,7 @@ inline constexpr void PolygonalAddressing<4>::StaticSetup(void)
    edge_djmax[0] =  0; edge_djmax[1] = -1;
 
 /*              vertex-vertex                   vertex-edge                    vertex-face
-  
+
                       2                              -                   ---------------------
                                                      |                   |         |         |
                                                      2                   |    3    |    2    |
@@ -308,7 +296,7 @@ inline constexpr void PolygonalAddressing<4>::StaticSetup(void)
    vert_face[3][0] = -1; vert_face[3][1] =  0;
 
 /*                edge-vertex                               edge-face 
-  
+
                                  1          -----------          ---------------------
                                  |          |         |          |         |         |
                                  |          |    0    |          |    0    |    1    |
@@ -326,7 +314,7 @@ inline constexpr void PolygonalAddressing<4>::StaticSetup(void)
    edge_face[1][0][0] = -1; edge_face[1][0][1] =  0; edge_face[1][1][0] =  0; edge_face[1][1][1] =  0;
 
 /*          face-vertex           face-edge                      face-face
-  
+
                                                                 -----------
                                                                 |         |
                                                                 |    2    |

--- a/geodesic/requestable_tesselation.cc
+++ b/geodesic/requestable_tesselation.cc
@@ -304,13 +304,13 @@ void RequestableTesselation<poly_type, max_division>::FillVertCoordArrays(int le
    };
 };
 
-template class RequestableTesselation<POLY_HEXAHEDRON, 4>;
-template class RequestableTesselation<POLY_HEXAHEDRON, 5>;
-template class RequestableTesselation<POLY_HEXAHEDRON, 6>;
-template class RequestableTesselation<POLY_HEXAHEDRON, 7>;
-template class RequestableTesselation<POLY_ICOSAHEDRON, 4>;
-template class RequestableTesselation<POLY_ICOSAHEDRON, 5>;
-template class RequestableTesselation<POLY_ICOSAHEDRON, 6>;
-template class RequestableTesselation<POLY_ICOSAHEDRON, 7>;
+template class RequestableTesselation<PolyType::POLY_HEXAHEDRON, 4>;
+template class RequestableTesselation<PolyType::POLY_HEXAHEDRON, 5>;
+template class RequestableTesselation<PolyType::POLY_HEXAHEDRON, 6>;
+template class RequestableTesselation<PolyType::POLY_HEXAHEDRON, 7>;
+template class RequestableTesselation<PolyType::POLY_ICOSAHEDRON, 4>;
+template class RequestableTesselation<PolyType::POLY_ICOSAHEDRON, 5>;
+template class RequestableTesselation<PolyType::POLY_ICOSAHEDRON, 6>;
+template class RequestableTesselation<PolyType::POLY_ICOSAHEDRON, 7>;
 
 };

--- a/geodesic/spherical_tesselation.cc
+++ b/geodesic/spherical_tesselation.cc
@@ -6,7 +6,8 @@
 This file is part of the SPECTRUM suite of scientific numerical simulation codes. SPECTRUM stands for Space Plasma and Energetic Charged particle TRansport on Unstructured Meshes. The code simulates plasma or neutral particle flows using MHD equations on a grid, transport of cosmic rays using stochastic or grid based methods. The "unstructured" part refers to the use of a geodesic mesh providing a uniform coverage of the surface of a sphere.
 */
 
-#include "geodesic/spherical_tesselation.hh"
+#include <common/coordinates.hh>
+#include <geodesic/spherical_tesselation.hh>
 
 namespace Spectrum {
 
@@ -109,23 +110,23 @@ template <PolyType poly_type, int max_division>
 void SphericalTesselation<poly_type, max_division>::AllocateStorage(void)
 {
 // Number of elements at division 0
-   verts_per_face[0] = poly_p[poly_type];
-   edges_per_vert[0] = poly_q[poly_type];
+   verts_per_face[0] = poly_p[static_cast<int>(poly_type)];
+   edges_per_vert[0] = poly_q[static_cast<int>(poly_type)];
    nverts[0] = Polyhedron<poly_type>::Nv;
    nedges[0] = Polyhedron<poly_type>::Ne;
    nfaces[0] = Polyhedron<poly_type>::Nf;
-   children_per_face[0] = (poly_type == POLY_DODECAHEDRON ? 5 : 4);
-   newverts_at_edge[0] = (poly_type == POLY_DODECAHEDRON ? false : true);
-   newverts_at_face[0] = ((poly_type == POLY_HEXAHEDRON) || (poly_type == POLY_DODECAHEDRON) ? true : false);
+   children_per_face[0] = (poly_type == PolyType::POLY_DODECAHEDRON ? 5 : 4);
+   newverts_at_edge[0] = (poly_type == PolyType::POLY_DODECAHEDRON ? false : true);
+   newverts_at_face[0] = ((poly_type == PolyType::POLY_HEXAHEDRON) || (poly_type == PolyType::POLY_DODECAHEDRON) ? true : false);
 
 // Number of elements at divisions > 0
    for (auto div = 1; div <= max_division; div++) {
-      verts_per_face[div] = (poly_type == POLY_HEXAHEDRON ? 4 : 3);
+      verts_per_face[div] = (poly_type == PolyType::POLY_HEXAHEDRON ? 4 : 3);
       edges_per_vert[div] = 2 * verts_per_face[div] / (verts_per_face[div] - 2); // singular vertices have fewer
 
       children_per_face[div] = 4;
       newverts_at_edge[div] = true;
-      newverts_at_face[div] = (poly_type == POLY_HEXAHEDRON ? true : false);
+      newverts_at_face[div] = (poly_type == PolyType::POLY_HEXAHEDRON ? true : false);
 
       nfaces[div] = nfaces[div - 1] * children_per_face[div - 1];
       nverts[div] = nverts[div - 1];
@@ -153,9 +154,8 @@ void SphericalTesselation<poly_type, max_division>::AllocateStorage(void)
 
 // Calculate Cartesian vertex coordinates at division 0
    for (auto vert = 0; vert < nverts[0]; vert++) {
-      vert_cart[vert] = gv_nr;
-      vert_cart[vert].ToCartesian(cos(Polyhedron<poly_type>::vlat[vert]), sin(Polyhedron<poly_type>::vlat[vert]),
-                                  sin(Polyhedron<poly_type>::vlon[vert]), cos(Polyhedron<poly_type>::vlon[vert]));
+      vert_cart[vert] = Metric<CoordinateSystem::SphericalRTP>::PosToCart(GeoVector(1.0, M_PI_2 - Polyhedron<poly_type>::vlat[vert],
+                                                                                                  Polyhedron<poly_type>::vlon[vert]));
    };
 
 // Copy base polyhedron connectivity
@@ -533,7 +533,7 @@ void SphericalTesselation<poly_type, max_division>::VertEdgeConn(int div)
    TERR_TYPE err;
 
 // Build VE table, which is the reverse of EV table (EV must be available).
-   if ((poly_type == POLY_DODECAHEDRON) && div) {
+   if ((poly_type == PolyType::POLY_DODECAHEDRON) && div) {
       sing_vert = nfaces[0];
       sing_nbrs = verts_per_face[0];
       offset = nverts[0];
@@ -598,7 +598,7 @@ void SphericalTesselation<poly_type, max_division>::VertFaceConn(int div)
    TERR_TYPE err;
 
 // Build VF table, which is the reverse of FV table (FV must be available).
-   if ((poly_type == POLY_DODECAHEDRON) && div) {
+   if ((poly_type == PolyType::POLY_DODECAHEDRON) && div) {
       sing_vert = nfaces[0];
       sing_nbrs = verts_per_face[0];
       offset = nverts[0];
@@ -685,7 +685,7 @@ void SphericalTesselation<poly_type, max_division>::EdgeFaceConn(int div)
       if ((face1 < 0) || (face1 >= nfaces[div]) || (face2 < 0) || (face2 >= nfaces[div])) throw TessError(callerID, div, TESERR_MISMT, __LINE__);
 
 // Synchronize EV and EF such that EF[0] is on the left and EF[1] on the right of the vector from EV[0] to EV[1] as shown in the diagram below. We rely on CC ordering of the FV table.
-//
+
 /*
                  -
                 / \              -----------
@@ -751,7 +751,7 @@ void SphericalTesselation<poly_type, max_division>::FaceFaceConn(int div)
    int edge, face, face0, face1, it;
 
 // Use FE to find the edge, then pick the appropriate neighbor face. By the end of this loop FV, FE, anf FF tables are all synchronized as shown in the diagram below.
-//
+
 /*
                                                      -----------
             ----------2----------                    |         |
@@ -783,22 +783,22 @@ void SphericalTesselation<poly_type, max_division>::FaceFaceConn(int div)
    };
 };
 
-template class SphericalTesselation<POLY_TETRAHEDRON, 5>;
-template class SphericalTesselation<POLY_HEXAHEDRON, 5>;
-template class SphericalTesselation<POLY_OCTAHEDRON, 5>;
-template class SphericalTesselation<POLY_DODECAHEDRON, 5>;
-template class SphericalTesselation<POLY_ICOSAHEDRON, 5>;
+template class SphericalTesselation<PolyType::POLY_TETRAHEDRON, 5>;
+template class SphericalTesselation<PolyType::POLY_HEXAHEDRON, 5>;
+template class SphericalTesselation<PolyType::POLY_OCTAHEDRON, 5>;
+template class SphericalTesselation<PolyType::POLY_DODECAHEDRON, 5>;
+template class SphericalTesselation<PolyType::POLY_ICOSAHEDRON, 5>;
 
-template class SphericalTesselation<POLY_TETRAHEDRON, 6>;
-template class SphericalTesselation<POLY_HEXAHEDRON, 6>;
-template class SphericalTesselation<POLY_OCTAHEDRON, 6>;
-template class SphericalTesselation<POLY_DODECAHEDRON, 6>;
-template class SphericalTesselation<POLY_ICOSAHEDRON, 6>;
+template class SphericalTesselation<PolyType::POLY_TETRAHEDRON, 6>;
+template class SphericalTesselation<PolyType::POLY_HEXAHEDRON, 6>;
+template class SphericalTesselation<PolyType::POLY_OCTAHEDRON, 6>;
+template class SphericalTesselation<PolyType::POLY_DODECAHEDRON, 6>;
+template class SphericalTesselation<PolyType::POLY_ICOSAHEDRON, 6>;
 
-template class SphericalTesselation<POLY_TETRAHEDRON, 7>;
-template class SphericalTesselation<POLY_HEXAHEDRON, 7>;
-template class SphericalTesselation<POLY_OCTAHEDRON, 7>;
-template class SphericalTesselation<POLY_DODECAHEDRON, 7>;
-template class SphericalTesselation<POLY_ICOSAHEDRON, 7>;
+template class SphericalTesselation<PolyType::POLY_TETRAHEDRON, 7>;
+template class SphericalTesselation<PolyType::POLY_HEXAHEDRON, 7>;
+template class SphericalTesselation<PolyType::POLY_OCTAHEDRON, 7>;
+template class SphericalTesselation<PolyType::POLY_DODECAHEDRON, 7>;
+template class SphericalTesselation<PolyType::POLY_ICOSAHEDRON, 7>;
 
 };

--- a/geodesic/spherical_tesselation.hh
+++ b/geodesic/spherical_tesselation.hh
@@ -12,8 +12,8 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 #include <iostream>
 #include <cstdint>
 
-#include "common/vectors.hh"
-#include "geodesic/polyhedron.hh"
+#include <common/vectors.hh>
+#include <geometry/polyhedron.hh>
 
 namespace Spectrum {
 
@@ -155,10 +155,10 @@ protected:
 //! Cartesian coordinates of vertices on a unit sphere
    GeoVector* vert_cart = nullptr;
 
-//! Vertex-vertex connectivity array (not ordered)
+//! Vertex-vertex connectivity array (ordered counter-clockwise)
    int** vv_con[max_division + 1] = {nullptr};
 
-//! Vertex-edge connectivity array (not ordered)
+//! Vertex-edge connectivity array (ordered counter-clockwise)
    int** ve_con[max_division + 1] = {nullptr};
 
 //! Vertex-face connectivity array (ordered counter-clockwise)
@@ -266,7 +266,7 @@ return Number of neighbor vertices (same as edges and faces)
 template <PolyType poly_type, int max_division>
 SPECTRUM_DEVICE_FUNC inline int SphericalTesselation<poly_type, max_division>::NVertNbrs(int div, int vert) const
 {
-   if (poly_type == POLY_DODECAHEDRON) {
+   if (poly_type == PolyType::POLY_DODECAHEDRON) {
       if (!div) return edges_per_vert[0];
       else if ((vert >= nverts[0]) && (vert < nverts[0] + nfaces[0])) return verts_per_face[0];
       else return edges_per_vert[div];

--- a/geodesic/traversable_tesselation.cc
+++ b/geodesic/traversable_tesselation.cc
@@ -89,7 +89,8 @@ SPECTRUM_DEVICE_FUNC void TraversableTesselation<poly_type, max_division>::Step(
 This function performs a basic move that allow visiting every face in the tesselation. The base vertex ("vert1") determines the base edge (CC from the base vertex). The moves are defined for the t-face resting on its base edge, so that the base vertex is in the SW corner. They are S (dir=1) and E (dir=2).
 */
 template <int max_division>
-SPECTRUM_DEVICE_FUNC void TraversableTesselation<POLY_HEXAHEDRON, max_division>::Step(int div, int face1, int vert1, int dir, int& face2, int& vert2) const
+SPECTRUM_DEVICE_FUNC void TraversableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::Step(int div, int face1, int vert1,
+                                                                                                int dir, int& face2, int& vert2) const
 {
    int iv1, iv2;
    if ((dir < 0) || (dir >= verts_per_face[div])) return;
@@ -164,13 +165,13 @@ void TraversableTesselation<poly_type, max_division>::GetAllInsideFaceNative(int
 {
 
 // Pentagonal sectors are not allowed
-   if ((poly_type == POLY_DODECAHEDRON) && !divs) {
+   if ((poly_type == PolyType::POLY_DODECAHEDRON) && !divs) {
       PrintError(__FILE__, __LINE__, "Division 0 sectors not allowed for DOCECAHEDRON tesselation", true);
       return;
    };
 
 // TODO Implement triangular sectors with tetra- and tri-corners.
-   if ((poly_type == POLY_TETRAHEDRON) || (poly_type == POLY_OCTAHEDRON)) {
+   if ((poly_type == PolyType::POLY_TETRAHEDRON) || (poly_type == PolyType::POLY_OCTAHEDRON)) {
       PrintError(__FILE__, __LINE__, "Not implemented yet for TETRAHEDRON and OCTAHEDRON tesselations", true);
       return;
    };
@@ -512,8 +513,8 @@ void TraversableTesselation<poly_type, max_division>::GetAllInsideFaceNative(int
 A crawler through a square region consisting of a sector surrounded by a layer of ghost faces on each side. The crawl is performed in the QAS pattern starting from the base (SW) corner, and the index of each t-face visited and each vertex encountered are recorded. NB: The QAS is the addressing systems used by grid blocks.
 */
 template <int max_division>
-void TraversableTesselation<POLY_HEXAHEDRON, max_division>::GetAllInsideFaceNative(int divs, int sect, int divf, int nghost,
-                                                                                   int* flist, int* vlist, bool* corners) const
+void TraversableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::GetAllInsideFaceNative(int divs, int sect, int divf, int nghost,
+                                                                                             int* flist, int* vlist, bool* corners) const
 {
    int vert, face, iv, it, i, j, findex = 0, vindex = 0;
    
@@ -759,13 +760,13 @@ void TraversableTesselation<POLY_HEXAHEDRON, max_division>::GetAllInsideFaceNati
    };
 };
 
-template class TraversableTesselation<POLY_HEXAHEDRON, 4>;
-template class TraversableTesselation<POLY_HEXAHEDRON, 5>;
-template class TraversableTesselation<POLY_HEXAHEDRON, 6>;
-template class TraversableTesselation<POLY_HEXAHEDRON, 7>;
-template class TraversableTesselation<POLY_ICOSAHEDRON, 4>;
-template class TraversableTesselation<POLY_ICOSAHEDRON, 5>;
-template class TraversableTesselation<POLY_ICOSAHEDRON, 6>;
-template class TraversableTesselation<POLY_ICOSAHEDRON, 7>;
+template class TraversableTesselation<PolyType::POLY_HEXAHEDRON, 4>;
+template class TraversableTesselation<PolyType::POLY_HEXAHEDRON, 5>;
+template class TraversableTesselation<PolyType::POLY_HEXAHEDRON, 6>;
+template class TraversableTesselation<PolyType::POLY_HEXAHEDRON, 7>;
+template class TraversableTesselation<PolyType::POLY_ICOSAHEDRON, 4>;
+template class TraversableTesselation<PolyType::POLY_ICOSAHEDRON, 5>;
+template class TraversableTesselation<PolyType::POLY_ICOSAHEDRON, 6>;
+template class TraversableTesselation<PolyType::POLY_ICOSAHEDRON, 7>;
 
 };

--- a/geodesic/traversable_tesselation.hh
+++ b/geodesic/traversable_tesselation.hh
@@ -52,16 +52,16 @@ public:
 \author Vladimir Florinski
 */
 template <int max_division>
-class TraversableTesselation<POLY_HEXAHEDRON, max_division> : public RequestableTesselation<POLY_HEXAHEDRON, max_division>
+class TraversableTesselation<PolyType::POLY_HEXAHEDRON, max_division> : public RequestableTesselation<PolyType::POLY_HEXAHEDRON, max_division>
 {
-   using RequestableTesselation<POLY_HEXAHEDRON, max_division>::verts_per_face;
-   using RequestableTesselation<POLY_HEXAHEDRON, max_division>::edges_per_vert;
-   using RequestableTesselation<POLY_HEXAHEDRON, max_division>::nverts;
-   using RequestableTesselation<POLY_HEXAHEDRON, max_division>::vf_con;
-   using RequestableTesselation<POLY_HEXAHEDRON, max_division>::fv_con;
-   using RequestableTesselation<POLY_HEXAHEDRON, max_division>::ff_con;
-   using RequestableTesselation<POLY_HEXAHEDRON, max_division>::VertCC;
-   using RequestableTesselation<POLY_HEXAHEDRON, max_division>::IsInside;
+   using RequestableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::verts_per_face;
+   using RequestableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::edges_per_vert;
+   using RequestableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::nverts;
+   using RequestableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::vf_con;
+   using RequestableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::fv_con;
+   using RequestableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::ff_con;
+   using RequestableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::VertCC;
+   using RequestableTesselation<PolyType::POLY_HEXAHEDRON, max_division>::IsInside;
 
 protected:
 

--- a/geometry/polyhedron.hh
+++ b/geometry/polyhedron.hh
@@ -17,9 +17,6 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 
 namespace Spectrum {
 
-//! Number of polyhedron types
-#define N_POLYTYPES 8
-
 /*!
 \brief A class enumerating common polyhedra used as templates for mesh objects
 \author Vladimir Florinski
@@ -35,12 +32,13 @@ enum class PolyType {
    POLY_FIVE_SIDED_PRISM,
    POLY_DODECAHEDRON,
    POLY_SIX_SIDED_PRISM,
-   POLY_ICOSAHEDRON
+   POLY_ICOSAHEDRON,
+   N_POLYTYPES
 };
 
 //! Polyhedron names
-inline constexpr std::array<std::string_view, N_POLYTYPES> PolyNames = {"tetrahedron"     , "three sided prism", "hexahedron"     , "octahedron" ,
-                                                                        "five sided prism", "dodecahedron"     , "six sided prism", "icosahedron"};
+inline constexpr std::array<std::string_view, static_cast<size_t>(PolyType::N_POLYTYPES)> PolyNames
+   = {"tetrahedron", "three sided prism", "hexahedron", "octahedron", "five sided prism", "dodecahedron", "six sided prism", "icosahedron"};
 
 /*!
 \brief Schlafli symbol {p,q}
@@ -115,6 +113,9 @@ public:
 
 //! Default constructor
    SPECTRUM_DEVICE_FUNC constexpr Polyhedron(void);
+
+//! Print the readable type
+   SPECTRUM_DEVICE_FUNC constexpr std::string_view GetType(void);
 };
 
 /*!
@@ -127,6 +128,17 @@ SPECTRUM_DEVICE_FUNC inline constexpr Polyhedron<poly_type>::Polyhedron(void)
 {
    VertexCoords();
    SetConnectivity();
+};
+
+/*!
+\author Vladimir Florinski
+\date 06/23/2026
+\return Readable name of the polyhedron
+*/
+template <PolyType poly_type>
+SPECTRUM_DEVICE_FUNC inline constexpr std::string_view Polyhedron<poly_type>::GetType(void)
+{
+   return PolyNames[static_cast<size_t>(poly_type)];
 };
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/server_batl.hh
+++ b/src/server_batl.hh
@@ -11,37 +11,12 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 #define SPECTRUM_SERVER_BATL_HH
 
 #include "server_cartesian.hh"
+#include "batl_spectrum_interface.hh"
 
 namespace Spectrum {
 
 //! Flag to always request stencil directly from BATL for 1st order interpolation (0 = no, 1 = yes)
 #define REQUEST_STENCIL_FROM_BATL 0
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void wrapamr_clean();
-void wrapamr_read_header(const char*, int, int);
-void wrapamr_read_file(const char*, int, int, int);
-void wrapamr_read_file_partial(const char*, int, int, int, int, int*);
-void wrapamr_get_ndim(int*);
-void wrapamr_get_nvar(int*);
-void wrapamr_get_domain(double*, double*);
-void wrapamr_get_block_size(int*, int*, int*, int*);
-void wrapamr_get_data_serial(const double* pos, double* variables, int*);
-
-void spectrum_init_mpi(int comm);
-void spectrum_get_node(const double* pos, int* node);
-void spectrum_get_neighbor_node(int node, int i, int j, int k, int* neighbor_node, int* neighbor_level);
-void spectrum_get_interpolation_stencil(const double* pos, int* n_nodes, int* stencil_nodes, int* stencil_zones, double* stencil_weights);
-
-// FIXME debug only
-void spectrum_read_header(const char*, int, int);
-
-#ifdef __cplusplus
-}
-#endif
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 // ServerBATL class declaration

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -131,11 +131,13 @@ main_test_drawable_tesselation_SOURCES = main_test_drawable_tesselation.cc \
    $(SPBL_GEODESIC_DIR)/drawable_tesselation.hh \
    $(SPBL_GEODESIC_DIR)/spherical_tesselation.cc \
    $(SPBL_GEODESIC_DIR)/spherical_tesselation.hh \
-   $(SPBL_GEODESIC_DIR)/polyhedron.hh \
+   $(SPBL_GEOMETRY_DIR)/polyhedron.hh \
+   $(SPBL_COMMON_DIR)/coordinates.hh \
    $(SPBL_COMMON_DIR)/vectors.cc \
    $(SPBL_COMMON_DIR)/vectors.hh \
    $(SPBL_COMMON_DIR)/multi_index.hh \
    $(SPBL_COMMON_DIR)/simple_array.hh \
+   $(SPBL_COMMON_DIR)/arithmetic.hh \
    $(SPBL_COMMON_DIR)/definitions.hh \
    $(SPBL_COMMON_DIR)/print_warn.hh \
    $(SPBL_COMMON_DIR)/gpu_config.hh
@@ -152,6 +154,7 @@ main_test_drawable_sector_SOURCES = main_test_drawable_sector.cc \
    $(SPBL_COMMON_DIR)/vectors.hh \
    $(SPBL_COMMON_DIR)/multi_index.hh \
    $(SPBL_COMMON_DIR)/simple_array.hh \
+   $(SPBL_COMMON_DIR)/arithmetic.hh \
    $(SPBL_COMMON_DIR)/definitions.hh \
    $(SPBL_COMMON_DIR)/print_warn.hh \
    $(SPBL_COMMON_DIR)/gpu_config.hh

--- a/tests/main_test_drawable_sector.cc
+++ b/tests/main_test_drawable_sector.cc
@@ -1,26 +1,47 @@
 // g++ -I.. -Wall -Wno-comment -std=c++20 -DGEO_DEBUG -g -O0 -o main_test_drawable_sector main_test_drawable_sector.cc ../geodesic/drawable_sector.cc ../geodesic/geodesic_sector.cc ../common/vectors.cc
+// ./main_test_drawable_sector <vert_per_face> <face_division> <sect_division> <ghost_width>
 
-#include "common/definitions.hh"
-#include "geodesic/drawable_sector.hh"
+#include <common/definitions.hh>
+#include <geodesic/drawable_sector.hh>
 
 using namespace Spectrum;
 
-const int face_division = 4;
-const int sect_division = 1;
-const int ghost_width = 3;
-
-int main(int argc, char *argv[])
+int main(int argc, char** argv)
 {
+   int vert_per_face;
+   int face_division = 4;
+   int sect_division = 1;
+   int ghost_width = 3;
+
+   if (argc > 1) vert_per_face = atoi(argv[1]);
+   if ((vert_per_face < 3) || (vert_per_face > 4)) vert_per_face = 3;
+   if (argc > 2) face_division = atoi(argv[2]);
+   if (argc > 3) sect_division = atoi(argv[3]);
+   if (argc > 4) ghost_width = atoi(argv[4]);
+
    DrawableSector<3> sector3(Pow2(face_division - sect_division), ghost_width);
-   sector3.Draw(1);
-   sector3.Draw(2);
-   sector3.Draw(3);
-
    DrawableSector<4> sector4(Pow2(face_division - sect_division), ghost_width);
-   sector4.Draw(1);
-   sector4.Draw(2);
-   sector4.Draw(3);
 
-   return 0;
+   for (auto type = 1; type <= 3; type++) {
+      std::cerr << std::endl;
+      if (vert_per_face == 3) sector3.PrintAddresses(type);
+      else sector4.PrintAddresses(type);
+   };
+   for (auto type = 1; type <= 9; type++) {
+      if (type != 5) {
+         std::cerr << std::endl;
+         if (vert_per_face == 3) sector3.PrintConn(type);
+         else sector4.PrintConn(type);
+      };
+   };
+   for (auto type = 1; type <= 3; type++) {
+      std::cerr << std::endl;
+      if (vert_per_face == 3) sector3.PrintMask(type);
+      else sector4.PrintMask(type);
+   };
+   for (auto type = 1; type <= 3; type++) {
+      std::cerr << std::endl;
+      if (vert_per_face == 3) sector3.Draw(type);
+      else sector4.Draw(type);
+   };
 };
-

--- a/tests/main_test_drawable_sector.cc
+++ b/tests/main_test_drawable_sector.cc
@@ -1,26 +1,67 @@
 // g++ -I.. -Wall -Wno-comment -std=c++20 -DGEO_DEBUG -g -O0 -o main_test_drawable_sector main_test_drawable_sector.cc ../geodesic/drawable_sector.cc ../geodesic/geodesic_sector.cc ../common/vectors.cc
-// ./main_test_drawable_sector <vert_per_face> <face_division> <sect_division> <ghost_width>
+// ./main_test_drawable_sector -v <vert_per_face> -d <div_dif> -g <ghost_width>
 
-#include <common/definitions.hh>
+#include <config.h>
+
+#ifndef USE_CXXOPTS
+#error This software requires cxxopts library to build
+#endif
+
+#include <cxxopts.hpp>
+#include <common/print_warn.hh>
 #include <geodesic/drawable_sector.hh>
 
 using namespace Spectrum;
 
+/*!
+\brief parse the command-line parameters 
+\author Vladimir Florinski
+\date 06/29/2026
+\param[in]  argc        Number of command-line arguments plus one
+\param[in]  argv        Command-line arguments
+\param[out] vert_face   Vertices per face (3 or 4)
+\param[out] div_dif     Difference between face and sector divisions
+\param[out] ghost_width Width of ghost zone halo
+\return True on success, false if some of the parameters were bad 
+*/
+bool ParseCLOpts(int argc, char** argv, int& vert_face, int& div_dif, int& ghost_width)
+{
+// Declare the command line options
+   cxxopts::Options options("main_test_drawable_sector", "Visualize element numbering and print neighbor information within a sector");
+   options.add_options()("v,vert_face", "Vertices per face (3 or 4)", cxxopts::value<int>()->default_value("3"))
+                        ("d,div_dif", "Difference between face and sector divisions", cxxopts::value<int>()->default_value("3"))
+                        ("g,ghost_width", "Width of ghost zone halo", cxxopts::value<int>()->default_value("1"));
+
+   auto result = options.parse(argc, argv);
+
+   vert_face = result["vert_face"].as<int>();
+   div_dif = result["div_dif"].as<int>();
+   ghost_width = result["ghost_width"].as<int>();
+
+   if ((vert_face < 3) || (vert_face > 4)) {
+      std::cerr << "The \"vert_face\" argument must be either 3 or 4\n";
+      return false;
+   };
+   if (div_dif < 1) {
+      std::cerr << "\"div_dif\" must be greater than 1\n";
+      return false;
+   };
+
+   int width = Pow2(div_dif);
+   if (width < min_width_to_ghost * ghost_width) {
+      std::cerr << "\"ghost_width\" is too large\n";
+      return false;
+   };
+   return true;
+};
+
 int main(int argc, char** argv)
 {
-   int vert_per_face;
-   int face_division = 4;
-   int sect_division = 1;
-   int ghost_width = 3;
+   int vert_per_face, div_dif, ghost_width;
+   if (!ParseCLOpts(argc, argv, vert_per_face, div_dif, ghost_width)) return 1;
 
-   if (argc > 1) vert_per_face = atoi(argv[1]);
-   if ((vert_per_face < 3) || (vert_per_face > 4)) vert_per_face = 3;
-   if (argc > 2) face_division = atoi(argv[2]);
-   if (argc > 3) sect_division = atoi(argv[3]);
-   if (argc > 4) ghost_width = atoi(argv[4]);
-
-   DrawableSector<3> sector3(Pow2(face_division - sect_division), ghost_width);
-   DrawableSector<4> sector4(Pow2(face_division - sect_division), ghost_width);
+   DrawableSector<3> sector3(Pow2(div_dif), ghost_width);
+   DrawableSector<4> sector4(Pow2(div_dif), ghost_width);
 
    for (auto type = 1; type <= 3; type++) {
       std::cerr << std::endl;

--- a/tests/main_test_drawable_tesselation.cc
+++ b/tests/main_test_drawable_tesselation.cc
@@ -1,21 +1,60 @@
 // g++ -I.. -Wall -std=c++20 -DGEO_DEBUG -DUSE_SILO -g -O0 -o main_test_drawable_tesselation main_test_drawable_tesselation.cc ../geodesic/spherical_tesselation.cc ../geodesic/drawable_tesselation.cc ../common/vectors.cc
-// ./main_test_drawable_tesselation <conn_division> <draw_division>
+// ./main_test_drawable_tesselation -c <conn_division> -d <draw_division>
 
+#include <config.h>
+
+#ifndef USE_CXXOPTS
+#error This software requires cxxopts library to build
+#endif
+
+#include <cxxopts.hpp>
 #include <common/print_warn.hh>
 #include <geodesic/drawable_tesselation.hh>
 
 using namespace Spectrum;
 
 // Edit these to your needs
-const PolyType poly_type = PolyType::POLY_HEXAHEDRON;
+const PolyType poly_type = PolyType::POLY_ICOSAHEDRON;
 const int max_division = 6;
+
+/*!
+\brief parse the command-line parameters 
+\author Vladimir Florinski
+\date 06/26/2026
+\param[in]  argc     Number of command-line arguments plus one
+\param[in]  argv     Command-line arguments
+\param[out] conn_div Division for which connectivity will be printed
+\param[out] draw_div Division for which images will be generated
+\return True on success, false if some of the parameters were bad 
+*/
+bool ParseCLOpts(int argc, char** argv, int& conn_div, int& draw_div)
+{
+// Declare the command line options
+   cxxopts::Options options("main_test_drawable_tesselation", "Test the tesselation class and print diagnostic information");
+   options.add_options()("c,conn_div", "Division for which connectivity will be printed", cxxopts::value<int>()->default_value("0"))
+                        ("d,draw_div", "Division for which images will be generated", cxxopts::value<int>()->default_value("0"));
+
+   auto result = options.parse(argc, argv);
+
+   conn_div = result["conn_div"].as<int>();
+   draw_div = result["draw_div"].as<int>();
+
+   if ((conn_div < 0) || (conn_div > max_division)) {
+      std::cerr << "The \"conn_div\" argument must be between 0 and " << max_division << std::endl;
+      return false;
+   };
+   if ((draw_div < 0) || (draw_div > max_division)) {
+      std::cerr << "The \"draw_div\" argument must be between 0 and " << max_division << std::endl;
+      return false;
+   };
+
+   return true;
+};
 
 int main(int argc, char** argv)
 {
-   int conn_division = 0;
-   int draw_division = 3;
-   if (argc > 1) conn_division = atoi(argv[1]);
-   if (argc > 2) draw_division = atoi(argv[2]);
+   int conn_division, draw_division;
+   if (!ParseCLOpts(argc, argv, conn_division, draw_division)) return 1;
 
    DrawableTesselation<poly_type, max_division> tesselation;
    std::cerr << "Testing the tesselation class for type " << inf_color << tesselation.GetType() << std_color << " base solid\n";

--- a/tests/main_test_drawable_tesselation.cc
+++ b/tests/main_test_drawable_tesselation.cc
@@ -1,24 +1,36 @@
-// g++ -I.. -Wall -Wno-comment -std=c++20 -DGEO_DEBUG -DUSE_SILO -g -O0 -o main_test_drawable_tesselation main_test_drawable_tesselation.cc ../geodesic/spherical_tesselation.cc ../geodesic/drawable_tesselation.cc ../common/vectors.cc
+// g++ -I.. -Wall -std=c++20 -DGEO_DEBUG -DUSE_SILO -g -O0 -o main_test_drawable_tesselation main_test_drawable_tesselation.cc ../geodesic/spherical_tesselation.cc ../geodesic/drawable_tesselation.cc ../common/vectors.cc
+// ./main_test_drawable_tesselation <conn_division> <draw_division>
 
-#include "geodesic/drawable_tesselation.hh"
+#include <common/print_warn.hh>
+#include <geodesic/drawable_tesselation.hh>
 
 using namespace Spectrum;
 
-//#define POLY_TYPE POLY_TETRAHEDRON
-//#define POLY_TYPE POLY_HEXAHEDRON
-//#define POLY_TYPE POLY_OCTAHEDRON
-//#define POLY_TYPE POLY_DODECAHEDRON
-#define POLY_TYPE POLY_ICOSAHEDRON
-#define MAX_DIVISION 5
+// Edit these to your needs
+const PolyType poly_type = PolyType::POLY_HEXAHEDRON;
+const int max_division = 6;
 
 int main(int argc, char** argv)
 {
-   std::cerr << "Testing the tesselation class for type " << POLY_TYPE << " base solid\n";
+   int conn_division = 0;
+   int draw_division = 3;
+   if (argc > 1) conn_division = atoi(argv[1]);
+   if (argc > 2) draw_division = atoi(argv[2]);
 
-   DrawableTesselation<POLY_TYPE, MAX_DIVISION> tess;
-   tess.PrintStats();
-   tess.PrintConn(1, 1);
-   tess.TestConnectivity(MAX_DIVISION);
-   tess.DrawGridArcs(4, true, DegToRad(-100.0), DegToRad(-30.0), true);
+   DrawableTesselation<poly_type, max_division> tesselation;
+   std::cerr << "Testing the tesselation class for type " << inf_color << tesselation.GetType() << std_color << " base solid\n";
+
+   tesselation.PrintStats();
+   for (auto con = 1; con <= 9; con++) {
+      if (con != 5) {
+         std::cerr << std::endl;
+         tesselation.PrintConn(conn_division, con);
+      };
+   };
+   std::cerr << std::endl;
+   for (auto div = 0; div <= max_division; div++) {
+      std::cerr << "Testing connectivity at division " << div <<": ";
+      tesselation.TestConnectivity(div);
+   };
+   tesselation.DrawGridArcs(draw_division, true, DegToRad(-100.0), DegToRad(-30.0), true);
 };
-


### PR DESCRIPTION
Team, please verify that you can compile two of the test codes, "main_test_drawable_tesselation" and "main_test_drawable_sector" and interpret the output. The first code generates an isometric projection of a tesselated sphere. This must be imported into a visualizer, but Juan might want to write a Python script to automate the task. The second code produces PostScript output, so no extra processing is required. Each code requires command line parameters as described in the comments. There is also numerical output - try to understand what it means.