### PR TITLE
Add flags to fix BATL lib detection in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ AS_IF([test "x$with_batl" == "x"], [
       LDFLAGS="$LDFLAGS -L$BATL_LIBDIR"
 
 # Adds the found library to LIBS
-      AC_SEARCH_LIBS([wrapamr_read_header], [WRAPAMR wrapamr], [
+      AC_SEARCH_LIBS([wrapamr_read_header], [READAMR WRAPAMR wrapamr], [
          AC_DEFINE([USE_BATL], [1], [Using BATL])
          AC_MSG_NOTICE([BATL is enabled])
          HAVE_BATL=1
@@ -184,7 +184,8 @@ AS_IF([test "x$with_batl" == "x"], [
       ],
       [
          AC_MSG_WARN([BATL not found])
-      ]) 
+      ],
+      [$MPI_LIBS -lmpi_mpifh -lTIMING -lSHARE -lgfortran]) 
    ],
    [
       AC_MSG_WARN([BATL lib or include directory does not exist])
@@ -351,4 +352,3 @@ AC_CHECK_FUNCS([floor memset pow sqrt])
 AC_CONFIG_FILES([Makefile runs/Makefile tests/Makefile benchmarks/Makefile])
 
 AC_OUTPUT
-


### PR DESCRIPTION
This PR updates BATL detection in configure so SPECTRUM can find the BATL read interface more reliably in my build environment. Please test it if you have issues on this BATL module and if it works for your environment.

Changes:
- search for `wrapamr_read_header` in `READAMR` as well as the previous BATL library names
- include the extra dependent libraries needed by the BATL/Fortran interface during the configure check
- keep the rest of the BATL-enabled configure flow unchanged

Reason:
The BATL symbol is provided by `libREADAMR.a`, and the configure probe failed without the additional dependent libraries, causing BATL detection to report `BATL not found` even though the BATL install was present.

This change is limited to `configure.ac`.